### PR TITLE
Add Rust formatting checks to CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -30,6 +30,13 @@ steps:
   #################
   # Lint
   #################
+  - label: ":rust: Lint"
+    command: |
+      # echo "--- :rust: Running Clippy"
+      # make lint-rust
+
+      echo "--- :rust: Ensuring Code Conforms to rustfmt"
+      make fmt-check-rust
   - label: ":ruby: Rubocop + RSpec"
     # for now, running in the default queue to avoid the need of a Gemfile the root directory
     command: cd ruby && bundle install && bundle exec rubocop && bundle exec rspec

--- a/Makefile
+++ b/Makefile
@@ -124,6 +124,18 @@ unit-test:
 cli-test:
 	@./scripts/cli-test.sh
 
+lint-rust:
+	@# Help: Run the linter for Rust.
+	$(rust_docker_run) /bin/bash -c "rustup component add clippy && cargo clippy --all -- -D warnings && cargo clippy --tests --all -- -D warnings"
+
+fmt-rust:
+	@# Help: Run the formatter for Rust.
+	$(rust_docker_run) /bin/bash -c "rustup component add rustfmt && cargo fmt"
+
+fmt-check-rust:
+	@# Help: Check formatting for Rust.
+	$(rust_docker_run) /bin/bash -c "rustup component add rustfmt && cargo fmt --all -- --check"
+
 # Clean up build artifacts and temporary files
 clean:
 	@echo "🧹 Cleaning up build artifacts..."
@@ -145,6 +157,9 @@ help:
 	@echo "  test                   - Run all tests (unit and CLI) using Docker"
 	@echo "  unit-test              - Run unit tests only using Docker"
 	@echo "  cli-test               - Test CLI with sample data for both Android and PO formats using Docker"
+	@echo "  lint-rust              - Run the linter for Rust"
+	@echo "  fmt-rust               - Run the formatter for Rust"
+	@echo "  fmt-check-rust         - Check formatting for Rust"
 	@echo "  clean                  - Clean build artifacts and temporary files using Docker"
 	@echo "  help                   - Show this help message"
 	@echo ""

--- a/src/android/android_format.rs
+++ b/src/android/android_format.rs
@@ -23,7 +23,11 @@ pub struct XmlString {
     #[serde(rename = "@name")]
     pub name: String,
 
-    #[serde(rename = "@translatable", default, skip_serializing_if = "Option::is_none")]
+    #[serde(
+        rename = "@translatable",
+        default,
+        skip_serializing_if = "Option::is_none"
+    )]
     pub translatable: Option<String>,
 
     #[serde(rename = "$text")]
@@ -82,22 +86,21 @@ impl AndroidResources {
     pub fn from_xml(xml_content: &str) -> Result<Self> {
         // Extract comments using regex before serde parsing
         let comments = extract_comments_from_xml(xml_content)?;
-        
+
         // Deserialize the main structure using pure serde
         let xml_resources: XmlResources = quick_xml::de::from_str(xml_content)?;
-        
+
         let mut resources = AndroidResources::new();
-        
+
         // Process each resource item
         for (index, item) in xml_resources.items.iter().enumerate() {
             let comment = comments.get(&index).cloned();
             let variable_mapping = parse_variable_mapping(&comment)?;
-            
+
             match item {
                 XmlResource::String(xml_string) => {
-                    let translatable = xml_string.translatable.as_ref()
-                        .map(|t| t == "true");
-                    
+                    let translatable = xml_string.translatable.as_ref().map(|t| t == "true");
+
                     resources.strings.push(AndroidString {
                         name: xml_string.name.clone(),
                         value: xml_string.value.clone(),
@@ -108,11 +111,11 @@ impl AndroidResources {
                 }
                 XmlResource::Plurals(xml_plurals) => {
                     let mut items = HashMap::new();
-                    
+
                     for item in &xml_plurals.items {
                         items.insert(item.quantity.clone(), item.value.clone());
                     }
-                    
+
                     resources.plurals.push(AndroidPlural {
                         name: xml_plurals.name.clone(),
                         items,
@@ -128,21 +131,27 @@ impl AndroidResources {
 
     // `serde` does not parse / write comments; use `quick_xml` for writing
     pub fn to_xml(&self) -> Result<String> {
-        use quick_xml::{events::Event, Writer};
-        
+        use quick_xml::{Writer, events::Event};
+
         let mut writer = Writer::new_with_indent(Vec::new(), b' ', 2);
-        
+
         // Write XML declaration
-        writer.write_event(Event::Decl(quick_xml::events::BytesDecl::new("1.0", Some("utf-8"), None)))?;
-        
+        writer.write_event(Event::Decl(quick_xml::events::BytesDecl::new(
+            "1.0",
+            Some("utf-8"),
+            None,
+        )))?;
+
         // Start resources element
-        writer.write_event(Event::Start(quick_xml::events::BytesStart::new("resources")))?;
+        writer.write_event(Event::Start(quick_xml::events::BytesStart::new(
+            "resources",
+        )))?;
 
         // Write strings with comments
         for string in &self.strings {
             write_string_with_comment(&mut writer, string)?;
         }
-        
+
         // Write plural strings with comments
         for plural in &self.plurals {
             write_plural_with_comment(&mut writer, plural)?;
@@ -156,9 +165,12 @@ impl AndroidResources {
 }
 
 // Write a string element with its comment using the library's proper comment support
-fn write_string_with_comment(writer: &mut quick_xml::Writer<Vec<u8>>, string: &AndroidString) -> Result<()> {
+fn write_string_with_comment(
+    writer: &mut quick_xml::Writer<Vec<u8>>,
+    string: &AndroidString,
+) -> Result<()> {
     use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
-    
+
     // Write comment if present using the library's Event::Comment
     if let Some(comment) = &string.comment {
         let formatted_comment = format_comment_for_xml(comment);
@@ -168,7 +180,7 @@ fn write_string_with_comment(writer: &mut quick_xml::Writer<Vec<u8>>, string: &A
     // Create string element with attributes
     let mut elem = BytesStart::new("string");
     elem.push_attribute(("name", string.name.as_str()));
-    
+
     // Only add translatable attribute when explicitly set to false
     if let Some(false) = string.translatable {
         elem.push_attribute(("translatable", "false"));
@@ -182,9 +194,12 @@ fn write_string_with_comment(writer: &mut quick_xml::Writer<Vec<u8>>, string: &A
 }
 
 // Write a plurals element with its comment using the library's proper comment support
-fn write_plural_with_comment(writer: &mut quick_xml::Writer<Vec<u8>>, plural: &AndroidPlural) -> Result<()> {
+fn write_plural_with_comment(
+    writer: &mut quick_xml::Writer<Vec<u8>>,
+    plural: &AndroidPlural,
+) -> Result<()> {
     use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
-    
+
     // Write comment if present using the library's Event::Comment
     if let Some(comment) = &plural.comment {
         let formatted_comment = format_comment_for_xml(comment);
@@ -203,7 +218,7 @@ fn write_plural_with_comment(writer: &mut quick_xml::Writer<Vec<u8>>, plural: &A
         if let Some(value) = plural.items.get(*quantity) {
             let mut item_elem = BytesStart::new("item");
             item_elem.push_attribute(("quantity", *quantity));
-            
+
             writer.write_event(Event::Start(item_elem))?;
             writer.write_event(Event::Text(BytesText::new(value)))?;
             writer.write_event(Event::End(BytesEnd::new("item")))?;
@@ -225,17 +240,17 @@ fn format_comment_for_xml(comment: &str) -> String {
 // `serde` does not parse comments; use `quick_xml` event-based parsing to extract the comments
 fn extract_comments_from_xml(xml_content: &str) -> Result<HashMap<usize, String>> {
     use quick_xml::{Reader, events::Event};
-    
+
     fn is_resource_element(name: &[u8]) -> bool {
         matches!(name, b"string" | b"plurals")
     }
-    
+
     let mut comments = HashMap::new();
     let mut reader = Reader::from_str(xml_content);
     let mut buf = Vec::new();
     let mut pending_comment = None;
     let mut resource_index = 0;
-    
+
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Comment(comment)) => {
@@ -258,25 +273,28 @@ fn extract_comments_from_xml(xml_content: &str) -> Result<HashMap<usize, String>
         }
         buf.clear();
     }
-    
+
     Ok(comments)
 }
 
 fn parse_variable_mapping(comment: &Option<String>) -> Result<HashMap<String, String>> {
     let mut mapping = HashMap::new();
-    
+
     if let Some(comment_text) = comment {
         // Parse patterns like "%s = {$message}" or "%1$d = {$num_downloads}"
         // The $ should only be present if a \d+ is also present
         let re = Regex::new(r"(%(?:\d+\$)?[sdif])\s*=\s*\{\$(\w+)\}").unwrap();
-        
+
         for captures in re.captures_iter(comment_text) {
             if let (Some(placeholder), Some(variable)) = (captures.get(1), captures.get(2)) {
-                mapping.insert(placeholder.as_str().to_string(), variable.as_str().to_string());
+                mapping.insert(
+                    placeholder.as_str().to_string(),
+                    variable.as_str().to_string(),
+                );
             }
         }
     }
-    
+
     Ok(mapping)
 }
 
@@ -310,7 +328,10 @@ mod tests {
         assert_eq!(resources.strings.len(), 1);
         assert_eq!(resources.strings[0].name, "greeting");
         assert_eq!(resources.strings[0].value, "Hello %s");
-        assert_eq!(resources.strings[0].variable_mapping.get("%s"), Some(&"name".to_string()));
+        assert_eq!(
+            resources.strings[0].variable_mapping.get("%s"),
+            Some(&"name".to_string())
+        );
     }
 
     #[test]
@@ -327,9 +348,18 @@ mod tests {
         let resources = AndroidResources::from_xml(xml).unwrap();
         assert_eq!(resources.plurals.len(), 1);
         assert_eq!(resources.plurals[0].name, "items");
-        assert_eq!(resources.plurals[0].items.get("one"), Some(&"%d item".to_string()));
-        assert_eq!(resources.plurals[0].items.get("other"), Some(&"%d items".to_string()));
-        assert_eq!(resources.plurals[0].variable_mapping.get("%d"), Some(&"count".to_string()));
+        assert_eq!(
+            resources.plurals[0].items.get("one"),
+            Some(&"%d item".to_string())
+        );
+        assert_eq!(
+            resources.plurals[0].items.get("other"),
+            Some(&"%d items".to_string())
+        );
+        assert_eq!(
+            resources.plurals[0].variable_mapping.get("%d"),
+            Some(&"count".to_string())
+        );
     }
 
     #[test]
@@ -348,7 +378,7 @@ mod tests {
     fn test_parse_variable_mapping_regex() {
         let comment = "%s = {$name}, %1$d = {$count}";
         let mapping = parse_variable_mapping(&Some(comment.to_string())).unwrap();
-        
+
         assert_eq!(mapping.get("%s"), Some(&"name".to_string()));
         assert_eq!(mapping.get("%1$d"), Some(&"count".to_string()));
     }
@@ -358,12 +388,12 @@ mod tests {
         // Test various Android placeholder formats
         let comment = "%s = {$name}, %d = {$count}, %2$s = {$message}, %1$f = {$price}";
         let mapping = parse_variable_mapping(&Some(comment.to_string())).unwrap();
-        
+
         assert_eq!(mapping.get("%s"), Some(&"name".to_string()));
         assert_eq!(mapping.get("%d"), Some(&"count".to_string()));
         assert_eq!(mapping.get("%2$s"), Some(&"message".to_string()));
         assert_eq!(mapping.get("%1$f"), Some(&"price".to_string()));
-        
+
         // Test that invalid patterns are not matched
         let invalid_comment = "%$ = {$invalid}, %abc = {$wrong}";
         let invalid_mapping = parse_variable_mapping(&Some(invalid_comment.to_string())).unwrap();
@@ -373,10 +403,10 @@ mod tests {
     #[test]
     fn test_generate_xml() {
         let mut resources = AndroidResources::new();
-        
+
         let mut variable_mapping = HashMap::new();
         variable_mapping.insert("%s".to_string(), "name".to_string());
-        
+
         resources.strings.push(AndroidString {
             name: "greeting".to_string(),
             value: "Hello %s".to_string(),
@@ -424,30 +454,48 @@ mod tests {
 </resources>"#;
 
         let resources = AndroidResources::from_xml(xml).unwrap();
-        
+
         // Check that we properly extracted 2 strings and 1 plural
         assert_eq!(resources.strings.len(), 2);
         assert_eq!(resources.plurals.len(), 1);
-        
+
         // Check comment association
         assert!(resources.strings[0].comment.is_some());
-        assert_eq!(resources.strings[0].comment.as_ref().unwrap(), "Variable mapping: %s = {$name}");
-        
+        assert_eq!(
+            resources.strings[0].comment.as_ref().unwrap(),
+            "Variable mapping: %s = {$name}"
+        );
+
         assert!(resources.strings[1].comment.is_some());
-        assert_eq!(resources.strings[1].comment.as_ref().unwrap(), "No variable mapping needed");
-        
+        assert_eq!(
+            resources.strings[1].comment.as_ref().unwrap(),
+            "No variable mapping needed"
+        );
+
         assert!(resources.plurals[0].comment.is_some());
-        assert!(resources.plurals[0].comment.as_ref().unwrap().contains("Multi-line comment"));
-        
+        assert!(
+            resources.plurals[0]
+                .comment
+                .as_ref()
+                .unwrap()
+                .contains("Multi-line comment")
+        );
+
         // Check variable mapping was extracted correctly
-        assert_eq!(resources.strings[0].variable_mapping.get("%s"), Some(&"name".to_string()));
-        assert_eq!(resources.plurals[0].variable_mapping.get("%d"), Some(&"count".to_string()));
+        assert_eq!(
+            resources.strings[0].variable_mapping.get("%s"),
+            Some(&"name".to_string())
+        );
+        assert_eq!(
+            resources.plurals[0].variable_mapping.get("%d"),
+            Some(&"count".to_string())
+        );
     }
 
     #[test]
     fn test_multiline_comment_formatting() {
         let mut resources = AndroidResources::new();
-        
+
         // Create a resource with a multiline comment
         resources.strings.push(AndroidString {
             name: "long-description".to_string(),
@@ -458,12 +506,12 @@ mod tests {
         });
 
         let xml = resources.to_xml().unwrap();
-        
+
         // Check that the comment has proper spacing and indentation
         assert!(xml.contains("<!-- Multi-line string with indentation"));
         assert!(xml.contains("     with a multi-line comment"));
         assert!(xml.contains("     as comments also are being parsed -->"));
-        
+
         // Verify it can round-trip correctly
         let parsed_resources = AndroidResources::from_xml(&xml).unwrap();
         assert_eq!(parsed_resources.strings.len(), 1);

--- a/src/android/converter.rs
+++ b/src/android/converter.rs
@@ -4,8 +4,11 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-use crate::android::android_format::{AndroidResources, AndroidString, AndroidPlural};
-use crate::shared::fluent_data::{FluentResource, FluentMessage, FluentPattern, FluentElement, format_string_value_as_multiline_fluent_text};
+use crate::android::android_format::{AndroidPlural, AndroidResources, AndroidString};
+use crate::shared::fluent_data::{
+    FluentElement, FluentMessage, FluentPattern, FluentResource,
+    format_string_value_as_multiline_fluent_text,
+};
 
 // Constants
 const DEFAULT_COUNT_VARIABLE: &str = "count";
@@ -13,10 +16,10 @@ const DEFAULT_COUNT_VARIABLE: &str = "count";
 pub fn fluent_to_android(input_path: &Path, output_path: &Path) -> Result<()> {
     let fluent_content = fs::read_to_string(input_path)?;
     let fluent_resource = FluentResource::from_source(&fluent_content)?;
-    
+
     let android_resources = convert_fluent_to_android(&fluent_resource)?;
     let xml_content = android_resources.to_xml()?;
-    
+
     fs::write(output_path, xml_content)?;
     Ok(())
 }
@@ -24,31 +27,31 @@ pub fn fluent_to_android(input_path: &Path, output_path: &Path) -> Result<()> {
 pub fn android_to_fluent(input_path: &Path, output_path: &Path) -> Result<()> {
     let xml_content = fs::read_to_string(input_path)?;
     let android_resources = AndroidResources::from_xml(&xml_content)?;
-    
+
     let conversion_context = ConversionContext::default();
     let fluent_resource = convert_android_to_fluent(&android_resources, &conversion_context)?;
     let fluent_content = fluent_resource.to_source();
-    
+
     fs::write(output_path, fluent_content)?;
     Ok(())
 }
 
 pub fn android_to_fluent_with_original(
-    xml_input_path: &Path, 
-    fluent_output_path: &Path, 
-    original_fluent_path: &Path
+    xml_input_path: &Path,
+    fluent_output_path: &Path,
+    original_fluent_path: &Path,
 ) -> Result<()> {
     let xml_content = fs::read_to_string(xml_input_path)?;
     let android_resources = AndroidResources::from_xml(&xml_content)?;
-    
+
     // Parse the original Fluent file to extract variable mappings and comments
     let original_fluent_content = fs::read_to_string(original_fluent_path)?;
     let original_fluent_resource = FluentResource::from_source(&original_fluent_content)?;
-    
+
     let conversion_context = ConversionContext::from_original_fluent(&original_fluent_resource)?;
     let fluent_resource = convert_android_to_fluent(&android_resources, &conversion_context)?;
     let fluent_content = fluent_resource.to_source();
-    
+
     fs::write(fluent_output_path, fluent_content)?;
     Ok(())
 }
@@ -65,13 +68,13 @@ impl ConversionContext {
         let mut plural_selectors = HashMap::new();
         let mut string_variables = HashMap::new();
         let mut original_comments = HashMap::new();
-        
+
         for message in &fluent.messages {
             // Store original comments
             if let Some(comment) = &message.comment {
                 original_comments.insert(message.id.clone(), comment.clone());
             }
-            
+
             if let Some(value) = &message.value {
                 match classify_pattern(value) {
                     PatternType::Plural => {
@@ -85,7 +88,8 @@ impl ConversionContext {
                     }
                     PatternType::Simple => {
                         // Extract variable names from simple patterns
-                        let vars: Vec<String> = value.elements
+                        let vars: Vec<String> = value
+                            .elements
                             .iter()
                             .filter_map(|element| {
                                 if let FluentElement::Variable(var_name) = element {
@@ -95,7 +99,7 @@ impl ConversionContext {
                                 }
                             })
                             .collect();
-                        
+
                         if !vars.is_empty() {
                             string_variables.insert(message.id.clone(), vars);
                         }
@@ -103,22 +107,22 @@ impl ConversionContext {
                 }
             }
         }
-        
+
         Ok(Self {
             plural_selectors,
             string_variables,
             original_comments,
         })
     }
-    
+
     fn get_original_comment(&self, id: &str) -> Option<&String> {
         self.original_comments.get(id)
     }
-    
+
     fn get_string_variables(&self, id: &str) -> Option<&Vec<String>> {
         self.string_variables.get(id)
     }
-    
+
     fn get_plural_selector(&self, id: &str) -> Option<&String> {
         self.plural_selectors.get(id)
     }
@@ -131,7 +135,8 @@ enum PatternType {
 }
 
 fn classify_pattern(pattern: &FluentPattern) -> PatternType {
-    pattern.elements
+    pattern
+        .elements
         .iter()
         .find_map(|element| {
             if matches!(element, FluentElement::Plural { .. }) {
@@ -165,8 +170,8 @@ fn convert_fluent_to_android(fluent: &FluentResource) -> Result<AndroidResources
 }
 
 fn convert_android_to_fluent(
-    android: &AndroidResources, 
-    context: &ConversionContext
+    android: &AndroidResources,
+    context: &ConversionContext,
 ) -> Result<FluentResource> {
     let mut fluent_messages = Vec::new();
 
@@ -222,7 +227,8 @@ fn convert_plural_pattern_to_android(
     message: &FluentMessage,
     pattern: &FluentPattern,
 ) -> Result<AndroidPlural> {
-    let plural_element = pattern.elements
+    let plural_element = pattern
+        .elements
         .iter()
         .find_map(|element| {
             if let FluentElement::Plural { selector, variants } = element {
@@ -238,7 +244,8 @@ fn convert_plural_pattern_to_android(
     let variable_mapping = HashMap::new(); // No longer needed since we keep variables as-is
 
     for (quantity, variant_pattern) in variants {
-        let android_value = convert_pattern_to_android_text_keeping_fluent_variables(variant_pattern)?;
+        let android_value =
+            convert_pattern_to_android_text_keeping_fluent_variables(variant_pattern)?;
         android_items.insert(map_fluent_to_android_quantity(quantity), android_value);
     }
 
@@ -281,8 +288,8 @@ fn convert_pattern_to_android_text_keeping_fluent_variables(
 }
 
 fn convert_android_string_to_fluent(
-    android_string: &AndroidString, 
-    context: &ConversionContext
+    android_string: &AndroidString,
+    context: &ConversionContext,
 ) -> Result<FluentMessage> {
     let original_variables = context.get_string_variables(&android_string.name);
     let fluent_pattern = convert_android_text_to_fluent_pattern(
@@ -291,7 +298,8 @@ fn convert_android_string_to_fluent(
         original_variables,
     )?;
 
-    let comment = context.get_original_comment(&android_string.name)
+    let comment = context
+        .get_original_comment(&android_string.name)
         .cloned()
         .or_else(|| android_string.comment.clone());
 
@@ -304,12 +312,12 @@ fn convert_android_string_to_fluent(
 }
 
 fn convert_android_plural_to_fluent(
-    android_plural: &AndroidPlural, 
-    context: &ConversionContext
+    android_plural: &AndroidPlural,
+    context: &ConversionContext,
 ) -> Result<FluentMessage> {
     let selector = determine_plural_selector(android_plural, context);
     let effective_mapping = create_effective_mapping(android_plural, &selector);
-    
+
     let mut variants = HashMap::new();
     for (quantity, android_text) in &android_plural.items {
         let variant_pattern = convert_android_text_to_fluent_pattern(
@@ -321,15 +329,16 @@ fn convert_android_plural_to_fluent(
         variants.insert(fluent_quantity, variant_pattern);
     }
 
-    let plural_element = FluentElement::Plural { 
-        selector: selector.clone(), 
-        variants 
+    let plural_element = FluentElement::Plural {
+        selector: selector.clone(),
+        variants,
     };
     let pattern = FluentPattern {
         elements: vec![plural_element],
     };
 
-    let comment = context.get_original_comment(&android_plural.name)
+    let comment = context
+        .get_original_comment(&android_plural.name)
         .cloned()
         .or_else(|| android_plural.comment.clone());
 
@@ -342,21 +351,21 @@ fn convert_android_plural_to_fluent(
 }
 
 fn determine_plural_selector(
-    android_plural: &AndroidPlural, 
-    context: &ConversionContext
+    android_plural: &AndroidPlural,
+    context: &ConversionContext,
 ) -> String {
     // Try to get from context first
     if let Some(selector) = context.get_plural_selector(&android_plural.name) {
         return selector.clone();
     }
-    
+
     // Try to extract from FluentVariable comment
     if let Some(comment) = &android_plural.comment {
         if let Some(selector) = extract_fluent_variable_from_comment(comment) {
             return selector;
         }
     }
-    
+
     // Fallback to default count variable
     DEFAULT_COUNT_VARIABLE.to_string()
 }
@@ -364,7 +373,7 @@ fn determine_plural_selector(
 fn extract_fluent_variable_from_comment(comment: &str) -> Option<String> {
     // Look for "FluentVariable: {$variableName}" pattern
     let re = Regex::new(r"FluentVariable:\s*\{\$([a-zA-Z_][a-zA-Z0-9_]*)\}").unwrap();
-    
+
     for line in comment.lines() {
         if let Some(captures) = re.captures(line.trim()) {
             if let Some(var_name) = captures.get(1) {
@@ -372,13 +381,13 @@ fn extract_fluent_variable_from_comment(comment: &str) -> Option<String> {
             }
         }
     }
-    
+
     None
 }
 
 fn create_effective_mapping(
-    android_plural: &AndroidPlural, 
-    _selector: &str
+    android_plural: &AndroidPlural,
+    _selector: &str,
 ) -> HashMap<String, String> {
     // Since we now use Fluent variables directly, we don't need complex mapping logic
     // Just return the existing mapping for any legacy support
@@ -398,25 +407,25 @@ fn convert_android_text_to_fluent_pattern(
 
     let mut elements = Vec::new();
     let mut last_end = 0;
-    
+
     // Handle Fluent variables
     for mat in fluent_var_regex.find_iter(&formatted_text) {
         // Add text before variable
         add_text_element_if_not_empty(&mut elements, &formatted_text[last_end..mat.start()]);
-        
+
         // Extract variable name from {$variableName}
         if let Some(captures) = fluent_var_regex.captures(mat.as_str()) {
             if let Some(var_name) = captures.get(1) {
                 elements.push(FluentElement::Variable(var_name.as_str().to_string()));
             }
         }
-        
+
         last_end = mat.end();
     }
-    
+
     // Add remaining text
     add_text_element_if_not_empty(&mut elements, &formatted_text[last_end..]);
-    
+
     // Handle case with no variables
     if elements.is_empty() {
         elements.push(FluentElement::Text(formatted_text));
@@ -462,12 +471,15 @@ fn map_fluent_to_android_quantity(fluent_quantity: &str) -> String {
         // Keep named forms as-is (they should already be valid Android quantities)
         "zero" | "one" | "two" | "few" | "many" | "other" => fluent_quantity,
         // For any other numeric values or unknown quantities, map to "other"
-        _ => if fluent_quantity.chars().all(|c| c.is_ascii_digit()) {
-            "other"
-        } else {
-            fluent_quantity
+        _ => {
+            if fluent_quantity.chars().all(|c| c.is_ascii_digit()) {
+                "other"
+            } else {
+                fluent_quantity
+            }
         }
-    }.to_string()
+    }
+    .to_string()
 }
 
 /// Map Android quantity names back to Fluent quantity keys for round-trip conversion
@@ -478,15 +490,16 @@ fn map_android_to_fluent_quantity(android_quantity: &str) -> String {
         "two" => "2",
         "few" | "many" | "other" => android_quantity,
         _ => android_quantity,
-    }.to_string()
+    }
+    .to_string()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::collections::HashMap;
-    use tempfile::tempdir;
     use std::fs;
+    use tempfile::tempdir;
 
     #[test]
     fn test_fluent_to_android_file_simple() {
@@ -540,9 +553,11 @@ greeting = Hello, {$name}!
 
         // Fluent to Android
         assert!(fluent_to_android(&original_ftl_path, &xml_path).is_ok());
-        
+
         // Android to Fluent with original context for better variable name preservation
-        assert!(android_to_fluent_with_original(&xml_path, &final_ftl_path, &original_ftl_path).is_ok());
+        assert!(
+            android_to_fluent_with_original(&xml_path, &final_ftl_path, &original_ftl_path).is_ok()
+        );
 
         let final_content = fs::read_to_string(&final_ftl_path).unwrap();
         assert!(final_content.contains("hello = Hello World"));
@@ -569,7 +584,9 @@ item_count = {$count ->
         assert!(fluent_to_android(&original_ftl_path, &xml_path).is_ok());
 
         // Android to Fluent with context
-        assert!(android_to_fluent_with_original(&xml_path, &final_ftl_path, &original_ftl_path).is_ok());
+        assert!(
+            android_to_fluent_with_original(&xml_path, &final_ftl_path, &original_ftl_path).is_ok()
+        );
 
         let final_content = fs::read_to_string(final_ftl_path).unwrap();
         // Built-in serializer uses multiline formatting for plurals
@@ -578,7 +595,7 @@ item_count = {$count ->
         assert!(final_content.contains("[one] { $count } item"));
         assert!(final_content.contains("*[other] { $count } items"));
     }
-    
+
     #[test]
     fn test_fluent_to_android_with_comments_file() {
         let temp_dir = tempdir().unwrap();
@@ -599,7 +616,7 @@ item_count = {$count ->
         assert!(fluent_to_android(&input_path, &output_path).is_ok());
 
         let xml_content = fs::read_to_string(&output_path).unwrap();
-        
+
         // Check that comments are preserved in the XML output
         // Note: The comment extraction captures the last comment before each message
         assert!(xml_content.contains("This is a comment for a simple string"));
@@ -618,7 +635,10 @@ item_count = {$count ->
     #[test]
     fn test_unescape_android_string() {
         // Test HTML entity unescaping (main case now)
-        assert_eq!(unescape_android_string("Hello &quot;World&quot;"), "Hello \"World\"");
+        assert_eq!(
+            unescape_android_string("Hello &quot;World&quot;"),
+            "Hello \"World\""
+        );
         assert_eq!(unescape_android_string("Line1\\nLine2"), "Line1\nLine2");
         assert_eq!(unescape_android_string("Tab\\tHere"), "Tab\tHere");
         assert_eq!(unescape_android_string("Don&apos;t"), "Don't");
@@ -627,8 +647,8 @@ item_count = {$count ->
 
     #[test]
     fn test_convert_simple_pattern_to_android() {
-        use crate::shared::fluent_data::{FluentMessage, FluentPattern, FluentElement};
-        
+        use crate::shared::fluent_data::{FluentElement, FluentMessage, FluentPattern};
+
         let message = FluentMessage {
             id: "greeting".to_string(),
             value: Some(FluentPattern {
@@ -641,53 +661,57 @@ item_count = {$count ->
             attributes: HashMap::new(),
             comment: Some("This is a greeting message".to_string()),
         };
-        
+
         let pattern = message.value.as_ref().unwrap();
         let android_string = convert_simple_pattern_to_android(&message, pattern).unwrap();
-        
+
         assert_eq!(android_string.name, "greeting");
         assert_eq!(android_string.value, "Hello, {$name}!");
         assert_eq!(android_string.variable_mapping.len(), 0); // No mapping needed since we keep variables as-is
-        assert_eq!(android_string.comment, Some("This is a greeting message".to_string()));
+        assert_eq!(
+            android_string.comment,
+            Some("This is a greeting message".to_string())
+        );
     }
 
     #[test]
     fn test_convert_android_text_to_fluent_pattern() {
         let variable_mapping = HashMap::new(); // Not needed for Fluent variables
-        
+
         let pattern = convert_android_text_to_fluent_pattern(
             "Hello {$name}, you have {$count} items",
             &variable_mapping,
             None,
-        ).unwrap();
-        
+        )
+        .unwrap();
+
         assert_eq!(pattern.elements.len(), 5);
-        
+
         // Check the structure: "Hello " + {$name} + ", you have " + {$count} + " items"
         if let FluentElement::Text(text) = &pattern.elements[0] {
             assert_eq!(text, "Hello ");
         } else {
             panic!("Expected text element");
         }
-        
+
         if let FluentElement::Variable(var) = &pattern.elements[1] {
             assert_eq!(var, "name");
         } else {
             panic!("Expected variable element");
         }
-        
+
         if let FluentElement::Text(text) = &pattern.elements[2] {
             assert_eq!(text, ", you have ");
         } else {
             panic!("Expected text element");
         }
-        
+
         if let FluentElement::Variable(var) = &pattern.elements[3] {
             assert_eq!(var, "count");
         } else {
             panic!("Expected variable element");
         }
-        
+
         if let FluentElement::Text(text) = &pattern.elements[4] {
             assert_eq!(text, " items");
         } else {
@@ -697,14 +721,17 @@ item_count = {$count ->
 
     #[test]
     fn test_classify_pattern() {
-        use crate::shared::fluent_data::{FluentPattern, FluentElement};
-        
+        use crate::shared::fluent_data::{FluentElement, FluentPattern};
+
         // Simple pattern
         let simple_pattern = FluentPattern {
             elements: vec![FluentElement::Text("Hello".to_string())],
         };
-        assert!(matches!(classify_pattern(&simple_pattern), PatternType::Simple));
-        
+        assert!(matches!(
+            classify_pattern(&simple_pattern),
+            PatternType::Simple
+        ));
+
         // Plural pattern
         let plural_pattern = FluentPattern {
             elements: vec![FluentElement::Plural {
@@ -712,13 +739,16 @@ item_count = {$count ->
                 variants: HashMap::new(),
             }],
         };
-        assert!(matches!(classify_pattern(&plural_pattern), PatternType::Plural));
+        assert!(matches!(
+            classify_pattern(&plural_pattern),
+            PatternType::Plural
+        ));
     }
 
     #[test]
     fn test_positional_parameters_fluent_to_android() {
-        use crate::shared::fluent_data::{FluentMessage, FluentPattern, FluentElement};
-        
+        use crate::shared::fluent_data::{FluentElement, FluentMessage, FluentPattern};
+
         // Test with multiple variables to ensure all use Fluent variable format
         let message = FluentMessage {
             id: "multi_vars".to_string(),
@@ -736,64 +766,68 @@ item_count = {$count ->
             attributes: HashMap::new(),
             comment: None,
         };
-        
+
         let pattern = message.value.as_ref().unwrap();
         let android_string = convert_simple_pattern_to_android(&message, pattern).unwrap();
-        
+
         assert_eq!(android_string.name, "multi_vars");
-        assert_eq!(android_string.value, "Welcome {$name}, you have {$count} messages in {$folder}!");
+        assert_eq!(
+            android_string.value,
+            "Welcome {$name}, you have {$count} messages in {$folder}!"
+        );
         assert_eq!(android_string.variable_mapping.len(), 0); // No mapping needed since we keep variables as-is
     }
 
     #[test]
     fn test_positional_parameters_android_to_fluent() {
         let variable_mapping = HashMap::new(); // Not needed for Fluent variables
-        
+
         let pattern = convert_android_text_to_fluent_pattern(
             "Welcome {$name}, you have {$count} messages in {$folder}!",
             &variable_mapping,
             None,
-        ).unwrap();
-        
+        )
+        .unwrap();
+
         assert_eq!(pattern.elements.len(), 7);
-        
+
         // Check the structure
         if let FluentElement::Text(text) = &pattern.elements[0] {
             assert_eq!(text, "Welcome ");
         } else {
             panic!("Expected text element");
         }
-        
+
         if let FluentElement::Variable(var) = &pattern.elements[1] {
             assert_eq!(var, "name");
         } else {
             panic!("Expected variable element");
         }
-        
+
         if let FluentElement::Text(text) = &pattern.elements[2] {
             assert_eq!(text, ", you have ");
         } else {
             panic!("Expected text element");
         }
-        
+
         if let FluentElement::Variable(var) = &pattern.elements[3] {
             assert_eq!(var, "count");
         } else {
             panic!("Expected variable element");
         }
-        
+
         if let FluentElement::Text(text) = &pattern.elements[4] {
             assert_eq!(text, " messages in ");
         } else {
             panic!("Expected text element");
         }
-        
+
         if let FluentElement::Variable(var) = &pattern.elements[5] {
             assert_eq!(var, "folder");
         } else {
             panic!("Expected variable element");
         }
-        
+
         if let FluentElement::Text(text) = &pattern.elements[6] {
             assert_eq!(text, "!");
         } else {
@@ -805,19 +839,16 @@ item_count = {$count ->
     fn test_multiline_android_to_fluent_formatting() {
         // Test that multiline Android strings are correctly formatted with proper indentation
         let variable_mapping = HashMap::new();
-        
+
         // Test multiline Android text (using \n as Android would store it)
         let android_text = "This is line one\\nThis is line two\\nThis is line three";
-        
-        let pattern = convert_android_text_to_fluent_pattern(
-            android_text,
-            &variable_mapping,
-            None,
-        ).unwrap();
-        
+
+        let pattern =
+            convert_android_text_to_fluent_pattern(android_text, &variable_mapping, None).unwrap();
+
         // The pattern should have 1 text element containing the properly formatted multiline text
         assert_eq!(pattern.elements.len(), 1);
-        
+
         // Check that the element contains the expected multiline text with proper formatting
         if let FluentElement::Text(text) = &pattern.elements[0] {
             // The text should be formatted with proper indentation for Fluent
@@ -826,7 +857,7 @@ item_count = {$count ->
         } else {
             panic!("Expected text element");
         }
-        
+
         // Test that when this pattern is converted to Fluent source, it has proper indentation
         let temp_resource = FluentResource {
             messages: vec![FluentMessage {
@@ -836,19 +867,22 @@ item_count = {$count ->
                 comment: None,
             }],
         };
-        
+
         let fluent_content = temp_resource.to_source();
-        
+
         // The generated Fluent should have proper indentation
         assert!(fluent_content.contains("test-multiline ="));
         assert!(fluent_content.contains("This is line one"));
         assert!(fluent_content.contains("    This is line two"));
         assert!(fluent_content.contains("    This is line three"));
-        
+
         // Verify the generated Fluent can be parsed back without errors
         let reparsed = FluentResource::from_source(&fluent_content);
-        assert!(reparsed.is_ok(), "Generated multiline Fluent should be parseable without errors");
-        
+        assert!(
+            reparsed.is_ok(),
+            "Generated multiline Fluent should be parseable without errors"
+        );
+
         let reparsed_resource = reparsed.unwrap();
         assert_eq!(reparsed_resource.messages.len(), 1);
         assert_eq!(reparsed_resource.messages[0].id, "test-multiline");
@@ -871,7 +905,7 @@ item_count = {$count ->
         assert!(result.is_ok());
 
         let xml_content = fs::read_to_string(&output_path).unwrap();
-        
+
         // Verify the Android XML includes FluentVariable comment and Fluent variables
         assert!(xml_content.contains("FluentVariable: {$photoCount}"));
         assert!(xml_content.contains("{$userName} added {$photoCount} new photo to {$album}."));

--- a/src/android/mod.rs
+++ b/src/android/mod.rs
@@ -1,4 +1,4 @@
 pub mod android_format;
 pub mod converter;
 
-pub use converter::{fluent_to_android, android_to_fluent, android_to_fluent_with_original};
+pub use converter::{android_to_fluent, android_to_fluent_with_original, fluent_to_android};

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,17 +1,19 @@
+use anyhow::Result;
 use clap::{Parser, Subcommand};
 use std::path::PathBuf;
-use anyhow::Result;
 
 mod android;
 mod po;
 mod shared;
 
-use android::{fluent_to_android, android_to_fluent, android_to_fluent_with_original};
+use android::{android_to_fluent, android_to_fluent_with_original, fluent_to_android};
 use po::{fluent_to_po, po_to_fluent};
 
 #[derive(Parser)]
 #[command(name = "fluent-tools")]
-#[command(about = "A CLI tool to convert between Fluent and various formats (Android XML, GNU gettext PO)")]
+#[command(
+    about = "A CLI tool to convert between Fluent and various formats (Android XML, GNU gettext PO)"
+)]
 #[command(version)]
 struct Cli {
     #[command(subcommand)]
@@ -74,39 +76,67 @@ fn main() {
 
 fn run(cli: Cli) -> Result<()> {
     match cli.command {
-        Commands::Android { android_command } => {
-            match android_command {
-                FormatCommands::FromFluent { input, output, .. } => {
-                    fluent_to_android(&input, &output)?;
-                    println!("Successfully converted {} to {}", input.display(), output.display());
-                }
-                FormatCommands::ToFluent { input, output, original_fluent } => {
-                    match original_fluent {
-                        Some(original_fluent_path) => {
-                            android_to_fluent_with_original(&input, &output, &original_fluent_path)?;
-                            println!("Successfully converted {} to {} using original Fluent file {}", 
-                                     input.display(), output.display(), original_fluent_path.display());
-                        }
-                        None => {
-                            android_to_fluent(&input, &output)?;
-                            println!("Successfully converted {} to {}", input.display(), output.display());
-                        }
-                    }
-                }
+        Commands::Android { android_command } => match android_command {
+            FormatCommands::FromFluent { input, output, .. } => {
+                fluent_to_android(&input, &output)?;
+                println!(
+                    "Successfully converted {} to {}",
+                    input.display(),
+                    output.display()
+                );
             }
-        }
-        Commands::Po { po_command } => {
-            match po_command {
-                FormatCommands::FromFluent { input, output, locale, original_language_input } => {
-                    fluent_to_po(&input, &output, &locale.unwrap_or_else(|| "en-US".to_string()), original_language_input.as_deref())?;
-                    println!("Successfully converted {} to {}", input.display(), output.display());
+            FormatCommands::ToFluent {
+                input,
+                output,
+                original_fluent,
+            } => match original_fluent {
+                Some(original_fluent_path) => {
+                    android_to_fluent_with_original(&input, &output, &original_fluent_path)?;
+                    println!(
+                        "Successfully converted {} to {} using original Fluent file {}",
+                        input.display(),
+                        output.display(),
+                        original_fluent_path.display()
+                    );
                 }
-                FormatCommands::ToFluent { input, output, .. } => {
-                    po_to_fluent(&input, &output)?;
-                    println!("Successfully converted {} to {}", input.display(), output.display());
+                None => {
+                    android_to_fluent(&input, &output)?;
+                    println!(
+                        "Successfully converted {} to {}",
+                        input.display(),
+                        output.display()
+                    );
                 }
+            },
+        },
+        Commands::Po { po_command } => match po_command {
+            FormatCommands::FromFluent {
+                input,
+                output,
+                locale,
+                original_language_input,
+            } => {
+                fluent_to_po(
+                    &input,
+                    &output,
+                    &locale.unwrap_or_else(|| "en-US".to_string()),
+                    original_language_input.as_deref(),
+                )?;
+                println!(
+                    "Successfully converted {} to {}",
+                    input.display(),
+                    output.display()
+                );
             }
-        }
+            FormatCommands::ToFluent { input, output, .. } => {
+                po_to_fluent(&input, &output)?;
+                println!(
+                    "Successfully converted {} to {}",
+                    input.display(),
+                    output.display()
+                );
+            }
+        },
     }
 
     Ok(())

--- a/src/po/cldr_plural_rules.rs
+++ b/src/po/cldr_plural_rules.rs
@@ -1,8 +1,7 @@
 /// CLDR Plural Rules module
-/// 
+///
 /// This module contains the Unicode CLDR plural rules for various locales,
 /// providing proper plural form mapping for PO file generation.
-
 use std::collections::HashMap;
 
 /// Represents CLDR plural rule information for a specific locale
@@ -17,7 +16,11 @@ pub struct CldrPluralRule {
 }
 
 impl CldrPluralRule {
-    const fn new(locale: &'static str, plural_expression: &'static str, categories: &'static [&'static str]) -> Self {
+    const fn new(
+        locale: &'static str,
+        plural_expression: &'static str,
+        categories: &'static [&'static str],
+    ) -> Self {
         Self {
             locale,
             plural_expression,
@@ -40,7 +43,6 @@ static CLDR_PLURAL_RULES: &[CldrPluralRule] = &[
     CldrPluralRule::new("tr", "nplurals=1; plural=0;", &["other"]),
     CldrPluralRule::new("fa", "nplurals=1; plural=0;", &["other"]),
     CldrPluralRule::new("az", "nplurals=1; plural=0;", &["other"]),
-    
     // Languages with 2 forms (one, other)
     CldrPluralRule::new("en", "nplurals=2; plural=(n != 1);", &["one", "other"]),
     CldrPluralRule::new("de", "nplurals=2; plural=(n != 1);", &["one", "other"]),
@@ -60,48 +62,100 @@ static CLDR_PLURAL_RULES: &[CldrPluralRule] = &[
     CldrPluralRule::new("bg", "nplurals=2; plural=(n != 1);", &["one", "other"]),
     CldrPluralRule::new("et", "nplurals=2; plural=(n != 1);", &["one", "other"]),
     CldrPluralRule::new("lv", "nplurals=2; plural=(n != 1);", &["one", "other"]),
-    
     // French (2 forms but different rule)
     CldrPluralRule::new("fr", "nplurals=2; plural=(n > 1);", &["one", "other"]),
     CldrPluralRule::new("pt-br", "nplurals=2; plural=(n > 1);", &["one", "other"]),
-    
     // Languages with 3 forms (one, few, other)
-    CldrPluralRule::new("hr", "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);", &["one", "few", "other"]),
-    CldrPluralRule::new("sr", "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);", &["one", "few", "other"]),
-    CldrPluralRule::new("bs", "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);", &["one", "few", "other"]),
-    
+    CldrPluralRule::new(
+        "hr",
+        "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);",
+        &["one", "few", "other"],
+    ),
+    CldrPluralRule::new(
+        "sr",
+        "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);",
+        &["one", "few", "other"],
+    ),
+    CldrPluralRule::new(
+        "bs",
+        "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);",
+        &["one", "few", "other"],
+    ),
     // Russian/Ukrainian (3 forms: one, few, other)
-    CldrPluralRule::new("ru", "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);", &["one", "few", "other"]),
-    CldrPluralRule::new("uk", "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);", &["one", "few", "other"]),
-    CldrPluralRule::new("be", "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);", &["one", "few", "other"]),
-    
+    CldrPluralRule::new(
+        "ru",
+        "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);",
+        &["one", "few", "other"],
+    ),
+    CldrPluralRule::new(
+        "uk",
+        "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);",
+        &["one", "few", "other"],
+    ),
+    CldrPluralRule::new(
+        "be",
+        "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);",
+        &["one", "few", "other"],
+    ),
     // Polish (3 forms with complex rule)
-    CldrPluralRule::new("pl", "nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);", &["one", "few", "other"]),
-    
+    CldrPluralRule::new(
+        "pl",
+        "nplurals=3; plural=(n==1 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);",
+        &["one", "few", "other"],
+    ),
     // Czech/Slovak (3 forms)
-    CldrPluralRule::new("cs", "nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;", &["one", "few", "other"]),
-    CldrPluralRule::new("sk", "nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;", &["one", "few", "other"]),
-    
+    CldrPluralRule::new(
+        "cs",
+        "nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;",
+        &["one", "few", "other"],
+    ),
+    CldrPluralRule::new(
+        "sk",
+        "nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;",
+        &["one", "few", "other"],
+    ),
     // Lithuanian (3 forms)
-    CldrPluralRule::new("lt", "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);", &["one", "few", "other"]),
-    
+    CldrPluralRule::new(
+        "lt",
+        "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && (n%100<10 || n%100>=20) ? 1 : 2);",
+        &["one", "few", "other"],
+    ),
     // Romanian (3 forms)
-    CldrPluralRule::new("ro", "nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);", &["one", "few", "other"]),
-    
+    CldrPluralRule::new(
+        "ro",
+        "nplurals=3; plural=(n==1 ? 0 : (n==0 || (n%100 > 0 && n%100 < 20)) ? 1 : 2);",
+        &["one", "few", "other"],
+    ),
     // Slovenian (4 forms)
-    CldrPluralRule::new("sl", "nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);", &["one", "two", "few", "other"]),
-    
+    CldrPluralRule::new(
+        "sl",
+        "nplurals=4; plural=(n%100==1 ? 0 : n%100==2 ? 1 : n%100==3 || n%100==4 ? 2 : 3);",
+        &["one", "two", "few", "other"],
+    ),
     // Arabic (6 forms: zero, one, two, few, many, other)
-    CldrPluralRule::new("ar", "nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);", &["zero", "one", "two", "few", "many", "other"]),
-    
+    CldrPluralRule::new(
+        "ar",
+        "nplurals=6; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5);",
+        &["zero", "one", "two", "few", "many", "other"],
+    ),
     // Welsh (4 forms: zero, one, two, other)
-    CldrPluralRule::new("cy", "nplurals=4; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : 3);", &["zero", "one", "two", "other"]),
-    
+    CldrPluralRule::new(
+        "cy",
+        "nplurals=4; plural=(n==0 ? 0 : n==1 ? 1 : n==2 ? 2 : 3);",
+        &["zero", "one", "two", "other"],
+    ),
     // Gaelic (5 forms)
-    CldrPluralRule::new("gd", "nplurals=5; plural=(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : (n > 2 && n < 20) ? 2 : (n%10==1 && n%100!=11) ? 3 : 4;", &["one", "two", "few", "many", "other"]),
-    
+    CldrPluralRule::new(
+        "gd",
+        "nplurals=5; plural=(n==1 || n==11) ? 0 : (n==2 || n==12) ? 1 : (n > 2 && n < 20) ? 2 : (n%10==1 && n%100!=11) ? 3 : 4;",
+        &["one", "two", "few", "many", "other"],
+    ),
     // Irish (5 forms)
-    CldrPluralRule::new("ga", "nplurals=5; plural=(n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4);", &["one", "two", "few", "many", "other"]),
+    CldrPluralRule::new(
+        "ga",
+        "nplurals=5; plural=(n==1 ? 0 : n==2 ? 1 : n<7 ? 2 : n<11 ? 3 : 4);",
+        &["one", "two", "few", "many", "other"],
+    ),
 ];
 
 /// Default plural forms for unknown locales (English rules)
@@ -120,9 +174,9 @@ pub fn is_other_category(key: &str) -> bool {
 }
 
 /// Get the CLDR plural rules for a given locale
-/// 
+///
 /// Returns the PO-style plural forms expression.
-/// 
+///
 /// Note: CLDR categories for reference:
 /// - English: ["one", "other"]  
 /// - Russian: ["one", "few", "other"]
@@ -136,7 +190,7 @@ pub fn get_plural_forms_for_locale(locale: &str) -> &'static str {
             return rule.plural_expression;
         }
     }
-    
+
     // Try language part only (e.g. "en" from "en-US")
     let lang_part = locale.split('-').next().unwrap_or(locale);
     for rule in CLDR_PLURAL_RULES {
@@ -144,7 +198,7 @@ pub fn get_plural_forms_for_locale(locale: &str) -> &'static str {
             return rule.plural_expression;
         }
     }
-    
+
     // Default to English rules
     DEFAULT_PLURAL_FORMS
 }
@@ -157,7 +211,7 @@ pub fn get_cldr_categories_for_locale(locale: &str) -> &'static [&'static str] {
             return rule.categories;
         }
     }
-    
+
     // Try language part only (e.g. "en" from "en-US")
     let lang_part = locale.split('-').next().unwrap_or(locale);
     for rule in CLDR_PLURAL_RULES {
@@ -165,28 +219,28 @@ pub fn get_cldr_categories_for_locale(locale: &str) -> &'static [&'static str] {
             return rule.categories;
         }
     }
-    
+
     // Default to English categories
     &["one", "other"]
 }
 
 /// Map Fluent CLDR categories to PO msgstr indices (locale-aware)
-/// 
+///
 /// This function takes the CLDR categories from Fluent plural forms
 /// and maps them to the correct PO msgstr[n] indices based on the
 /// locale-specific CLDR ordering.
 pub fn map_cldr_categories_to_po_indices_for_locale(
-    forms: &[(String, String)], 
-    locale: &str
+    forms: &[(String, String)],
+    locale: &str,
 ) -> Vec<String> {
     let mut msgstr_forms = Vec::new();
-    
+
     // Create a map from CLDR category to text for quick lookup
     let mut form_map = HashMap::new();
     for (key, text) in forms {
         form_map.insert(key.as_str(), text.clone());
     }
-    
+
     // Use locale-specific CLDR categories in the correct order
     let locale_categories = get_cldr_categories_for_locale(locale);
     for &category in locale_categories {
@@ -194,14 +248,14 @@ pub fn map_cldr_categories_to_po_indices_for_locale(
             msgstr_forms.push(text.clone());
         }
     }
-    
+
     // Handle any numeric forms that weren't covered
     for (key, text) in forms {
         if key.chars().all(|c| c.is_ascii_digit()) && !msgstr_forms.contains(text) {
             msgstr_forms.push(text.clone());
         }
     }
-    
+
     // Ensure we have at least 2 forms for PO plural messages
     if msgstr_forms.len() < 2 {
         if let Some(first_form) = msgstr_forms.first() {
@@ -212,20 +266,21 @@ pub fn map_cldr_categories_to_po_indices_for_locale(
             msgstr_forms.push(String::new());
         }
     }
-    
+
     msgstr_forms
 }
 
 /// Map PO msgstr indices back to Fluent CLDR categories (locale-aware)
-/// 
+///
 /// This function reverses the mapping process, converting PO msgstr[n]
 /// entries back to the appropriate CLDR category names for the specific locale.
 pub fn map_po_indices_to_cldr_categories_for_locale(
-    msgstr_count: usize, 
-    locale: &str
+    msgstr_count: usize,
+    locale: &str,
 ) -> Vec<&'static str> {
     let locale_categories = get_cldr_categories_for_locale(locale);
-    locale_categories.iter()
+    locale_categories
+        .iter()
         .take(msgstr_count)
         .copied()
         .collect()
@@ -240,11 +295,11 @@ mod tests {
         // Test exact locale match
         let rule = get_plural_forms_for_locale("ru");
         assert!(rule.contains("nplurals=3"));
-        
+
         // Test language part extraction
         let rule = get_plural_forms_for_locale("en-US");
         assert!(rule.contains("nplurals=2"));
-        
+
         // Test default fallback
         let rule = get_plural_forms_for_locale("unknown");
         assert!(rule.contains("nplurals=2"));
@@ -253,19 +308,28 @@ mod tests {
     #[test]
     fn test_get_plural_forms_for_locale() {
         // Test that the simplified function returns just the plural forms string
-        assert_eq!(get_plural_forms_for_locale("en"), "nplurals=2; plural=(n != 1);");
-        assert_eq!(get_plural_forms_for_locale("ru"), "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);");
+        assert_eq!(
+            get_plural_forms_for_locale("en"),
+            "nplurals=2; plural=(n != 1);"
+        );
+        assert_eq!(
+            get_plural_forms_for_locale("ru"),
+            "nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);"
+        );
         assert_eq!(get_plural_forms_for_locale("zh"), "nplurals=1; plural=0;");
-        
+
         // Test unknown locale falls back to English
-        assert_eq!(get_plural_forms_for_locale("unknown"), "nplurals=2; plural=(n != 1);");
+        assert_eq!(
+            get_plural_forms_for_locale("unknown"),
+            "nplurals=2; plural=(n != 1);"
+        );
     }
 
     #[test]
     fn test_singular_helper() {
         assert!(is_singular_category("one"));
         assert!(is_singular_category("1"));
-        assert!(!is_singular_category("0"));  // "0" is grammatically plural
+        assert!(!is_singular_category("0")); // "0" is grammatically plural
         assert!(!is_singular_category("other"));
         assert!(!is_singular_category("few"));
     }
@@ -274,19 +338,25 @@ mod tests {
     fn test_get_cldr_categories_for_locale() {
         // Test English
         assert_eq!(get_cldr_categories_for_locale("en"), &["one", "other"]);
-        
+
         // Test Russian (3 forms)
-        assert_eq!(get_cldr_categories_for_locale("ru"), &["one", "few", "other"]);
-        
+        assert_eq!(
+            get_cldr_categories_for_locale("ru"),
+            &["one", "few", "other"]
+        );
+
         // Test Arabic (6 forms)
-        assert_eq!(get_cldr_categories_for_locale("ar"), &["zero", "one", "two", "few", "many", "other"]);
-        
+        assert_eq!(
+            get_cldr_categories_for_locale("ar"),
+            &["zero", "one", "two", "few", "many", "other"]
+        );
+
         // Test Chinese (1 form)
         assert_eq!(get_cldr_categories_for_locale("zh"), &["other"]);
-        
+
         // Test locale with region code
         assert_eq!(get_cldr_categories_for_locale("en-US"), &["one", "other"]);
-        
+
         // Test unknown locale (falls back to English)
         assert_eq!(get_cldr_categories_for_locale("unknown"), &["one", "other"]);
     }
@@ -299,17 +369,16 @@ mod tests {
             ("few".to_string(), "несколько элементов".to_string()),
             ("other".to_string(), "много элементов".to_string()),
         ];
-        
+
         let msgstr_forms = map_cldr_categories_to_po_indices_for_locale(&forms, "ru");
-        
+
         // Should be ordered according to Russian CLDR: one, few, other
         assert_eq!(msgstr_forms[0], "один элемент");
         assert_eq!(msgstr_forms[1], "несколько элементов");
         assert_eq!(msgstr_forms[2], "много элементов");
-        
+
         // Test reverse mapping
         let categories = map_po_indices_to_cldr_categories_for_locale(3, "ru");
         assert_eq!(categories, vec!["one", "few", "other"]);
     }
-
-} 
+}

--- a/src/po/converter.rs
+++ b/src/po/converter.rs
@@ -1,18 +1,23 @@
 use anyhow::Result;
-use std::path::Path;
 use std::fs;
+use std::path::Path;
 
-use crate::shared::fluent_data;
 use crate::po::po_format::{fluent_to_po_catalog, parse_po_file, po_catalog_to_fluent};
+use crate::shared::fluent_data;
 use polib::po_file;
 
-pub fn fluent_to_po(input_path: &Path, output_path: &Path, locale: &str, original_language_input: Option<&Path>) -> Result<()> {
+pub fn fluent_to_po(
+    input_path: &Path,
+    output_path: &Path,
+    locale: &str,
+    original_language_input: Option<&Path>,
+) -> Result<()> {
     // Read target Fluent file
     let fluent_content = fs::read_to_string(input_path)?;
-    
+
     // Parse target Fluent
     let fluent_resource = fluent_data::parse_fluent(&fluent_content)?;
-    
+
     // Read and parse source language file if provided
     let source_resource = if let Some(source_path) = original_language_input {
         let source_content = fs::read_to_string(source_path)?;
@@ -20,80 +25,88 @@ pub fn fluent_to_po(input_path: &Path, output_path: &Path, locale: &str, origina
     } else {
         None
     };
-    
+
     // Convert to PO
     let po_catalog = fluent_to_po_catalog(fluent_resource, locale, source_resource)?;
-    
+
     // Write PO file with proper CLDR plural forms
     po_file::write(&po_catalog, output_path)
         .map_err(|e| anyhow::anyhow!("Failed to write PO file: {}", e))?;
-    
+
     Ok(())
 }
 
 pub fn po_to_fluent(input_path: &Path, output_path: &Path) -> Result<()> {
     // Parse PO file
     let po_catalog = parse_po_file(input_path)?;
-    
+
     // Convert to FluentResource
     let fluent_resource = po_catalog_to_fluent(po_catalog)?;
-    
+
     // Format as properly spaced Fluent content
     let fluent_content = fluent_resource.to_source();
-    
+
     // Write Fluent file
     fs::write(output_path, fluent_content)?;
-    
+
     Ok(())
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use tempfile::tempdir;
     use std::fs;
+    use tempfile::tempdir;
 
     #[test]
     fn test_fluent_to_po_simple() {
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("input.ftl");
         let output_path = temp_dir.path().join("output.po");
-        
+
         // Create a simple Fluent file
         let fluent_content = r#"hello = Hello World
 greeting = Hello, {$name}!
 "#;
         fs::write(&input_path, fluent_content).unwrap();
-        
+
         // Convert to PO
         let result = fluent_to_po(&input_path, &output_path, "en", None);
         assert!(result.is_ok());
-        
+
         // Verify PO file was created
         assert!(output_path.exists());
         let po_content = fs::read_to_string(&output_path).unwrap();
-        
+
         // Verify we have the expected metadata header structure
-        assert!(po_content.contains("Project-Id-Version:"),
-                "PO file should contain required metadata headers");
-        assert!(po_content.contains("Content-Type: text/plain; charset=UTF-8"),
-                "PO file should contain proper content type header");
+        assert!(
+            po_content.contains("Project-Id-Version:"),
+            "PO file should contain required metadata headers"
+        );
+        assert!(
+            po_content.contains("Content-Type: text/plain; charset=UTF-8"),
+            "PO file should contain proper content type header"
+        );
 
         // Verify complete PO entry blocks with proper pairing of msgctxt, msgid, and msgstr
-        
+
         // Check for "hello" entry block
         let hello_block = r#"msgctxt "hello"
 msgid "Hello World"
 msgstr "Hello World""#;
-        assert!(po_content.contains(hello_block), 
-                "PO content should contain complete 'hello' entry block with properly paired msgctxt, msgid, and msgstr");
-        
-        // Check for "greeting" entry block  
+        assert!(
+            po_content.contains(hello_block),
+            "PO content should contain complete 'hello' entry block with properly paired msgctxt, msgid, and msgstr"
+        );
+
+        // Check for "greeting" entry block
         let greeting_block = r#"msgctxt "greeting"
 msgid "Hello, {$name}!"
 msgstr "Hello, {$name}!""#;
-        assert!(po_content.contains(greeting_block),
-                "PO content should contain complete 'greeting' entry block with properly paired msgctxt, msgid, and msgstr");
+        assert!(
+            po_content.contains(greeting_block),
+            "PO content should contain complete 'greeting' entry block with properly paired msgctxt, msgid, and msgstr"
+        );
     }
 
     #[test]
@@ -101,7 +114,7 @@ msgstr "Hello, {$name}!""#;
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("input.ftl");
         let output_path = temp_dir.path().join("output.po");
-        
+
         // Create a Fluent file with plurals
         let fluent_content = r#"count = {$num ->
     [one] {$num} item
@@ -109,18 +122,20 @@ msgstr "Hello, {$name}!""#;
 }
 "#;
         fs::write(&input_path, fluent_content).unwrap();
-        
+
         // Convert to PO
         let result = fluent_to_po(&input_path, &output_path, "en", None);
         assert!(result.is_ok());
-        
+
         // Verify PO file was created with plural forms
         assert!(output_path.exists());
         let po_content = fs::read_to_string(&output_path).unwrap();
 
         // Verify header metadata contains plural forms information
-        assert!(po_content.contains("Plural-Forms:"),
-                "Should contain Plural-Forms header for proper plural handling");
+        assert!(
+            po_content.contains("Plural-Forms:"),
+            "Should contain Plural-Forms header for proper plural handling"
+        );
 
         // Verify complete plural entry block with proper structure using standard PO format
         let plural_block = r#"#. FLUENT_SELECTOR:num
@@ -129,9 +144,10 @@ msgid "{$num} item"
 msgid_plural "{$num} items"
 msgstr[0] "{$num} item"
 msgstr[1] "{$num} items""#;
-        assert!(po_content.contains(plural_block),
-                "PO content should contain complete plural entry block with properly formatted FLUENT_SELECTOR comment, msgctxt, msgid, msgid_plural, and standard msgstr entries without FLUENT_ markers");
-        
+        assert!(
+            po_content.contains(plural_block),
+            "PO content should contain complete plural entry block with properly formatted FLUENT_SELECTOR comment, msgctxt, msgid, msgid_plural, and standard msgstr entries without FLUENT_ markers"
+        );
     }
 
     #[test]
@@ -162,11 +178,11 @@ msgid "Hello, {$name}!"
 msgstr "Hello, {$name}!"
 "#;
         fs::write(&input_path, po_content).unwrap();
-        
+
         // Convert to Fluent
         let result = po_to_fluent(&input_path, &output_path);
         assert!(result.is_ok());
-        
+
         // Verify Fluent file was created with expected content
         let fluent_content = fs::read_to_string(&output_path).unwrap();
         assert!(fluent_content.contains("hello = Hello World"));
@@ -179,7 +195,7 @@ msgstr "Hello, {$name}!"
         let original_ftl = temp_dir.path().join("original.ftl");
         let po_file = temp_dir.path().join("intermediate.po");
         let converted_ftl = temp_dir.path().join("converted.ftl");
-        
+
         // Original Fluent content with various complex cases including multiline values
         let original_content = r#"hello = Hello World
 greeting = Hello, {$name}!
@@ -196,18 +212,18 @@ instructions = Step 1: Click the {$button} button
     Step 3: Save your changes
 "#;
         fs::write(&original_ftl, original_content).unwrap();
-        
+
         // Convert Fluent to PO
         let result1 = fluent_to_po(&original_ftl, &po_file, "en", None);
         assert!(result1.is_ok());
-        
+
         // Convert PO back to Fluent
         let result2 = po_to_fluent(&po_file, &converted_ftl);
         assert!(result2.is_ok());
-        
+
         // Read the converted content
         let converted_content = fs::read_to_string(&converted_ftl).unwrap();
-        
+
         // Check that all messages are preserved, including multiline formatting
         assert!(converted_content.contains("hello = Hello World"));
         assert!(converted_content.contains("greeting = Hello, { $name }!"));
@@ -215,14 +231,14 @@ instructions = Step 1: Click the {$button} button
             r#"# This is a comment
 farewell = Goodbye, { $name }!"#
         ));
-        
+
         // Verify multiline content is preserved (without manual formatting expectations)
         // Note: The simplified approach relies on Fluent parser behavior
         assert!(converted_content.contains("description ="));
         assert!(converted_content.contains("This is the first line of a longer description."));
         assert!(converted_content.contains("This is the second line with proper indentation."));
         assert!(converted_content.contains("And this is the third line that should be preserved."));
-        
+
         // Verify multiline content with variables is preserved
         // Note: Variables are normalized with spaces by the built-in serializer
         assert!(converted_content.contains("instructions ="));
@@ -237,25 +253,25 @@ farewell = Goodbye, { $name }!"#
         let original_ftl = temp_dir.path().join("original.ftl");
         let po_file = temp_dir.path().join("intermediate.po");
         let converted_ftl = temp_dir.path().join("converted.ftl");
-        
+
         // Original Fluent content with plurals
         let original_content = r#"item_count = {$count ->
     [one] {$count} item
    *[other] {$count} items
 }"#;
         fs::write(&original_ftl, original_content).unwrap();
-        
+
         // Convert Fluent to PO
         let result1 = fluent_to_po(&original_ftl, &po_file, "en", None);
         assert!(result1.is_ok());
-        
+
         // Convert PO back to Fluent
         let result2 = po_to_fluent(&po_file, &converted_ftl);
         assert!(result2.is_ok());
-        
+
         // Read the converted content
         let converted_content = fs::read_to_string(&converted_ftl).unwrap();
-        
+
         // Check that the core message structure is preserved
         // Note: PO conversion adds FLUENT_SELECTOR comments for round-trip preservation
         assert!(converted_content.contains("item_count ="));
@@ -269,7 +285,7 @@ farewell = Goodbye, { $name }!"#
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("input.ftl");
         let output_path = temp_dir.path().join("output.po");
-        
+
         // Create a Fluent file with comments
         let fluent_content = r#"# This is a greeting message
 hello = Hello World
@@ -277,28 +293,32 @@ hello = Hello World
 greeting = Hello, {$name}!
 "#;
         fs::write(&input_path, fluent_content).unwrap();
-        
+
         // Convert to PO
         let result = fluent_to_po(&input_path, &output_path, "en", None);
         assert!(result.is_ok());
-        
+
         // Verify PO file contains comments with proper format
         let po_content = fs::read_to_string(&output_path).unwrap();
-        
+
         // Verify complete comment blocks with proper PO extracted comment format (#.)
         let hello_comment_block = r#"#. This is a greeting message
 msgctxt "hello"
 msgid "Hello World"
 msgstr "Hello World""#;
-        assert!(po_content.contains(hello_comment_block),
-                "Should contain complete 'hello' entry with properly formatted extracted comment using '#.' prefix");
-        
+        assert!(
+            po_content.contains(hello_comment_block),
+            "Should contain complete 'hello' entry with properly formatted extracted comment using '#.' prefix"
+        );
+
         let greeting_comment_block = r#"#. Welcome message for users
 msgctxt "greeting"
 msgid "Hello, {$name}!"
 msgstr "Hello, {$name}!""#;
-        assert!(po_content.contains(greeting_comment_block),
-                "Should contain complete 'greeting' entry with properly formatted extracted comment using '#.' prefix");
+        assert!(
+            po_content.contains(greeting_comment_block),
+            "Should contain complete 'greeting' entry with properly formatted extracted comment using '#.' prefix"
+        );
     }
 
     #[test]
@@ -306,7 +326,7 @@ msgstr "Hello, {$name}!""#;
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("nonexistent.ftl");
         let output_path = temp_dir.path().join("output.po");
-        
+
         // Try to convert non-existent file
         let result = fluent_to_po(&input_path, &output_path, "en", None);
         assert!(result.is_err());
@@ -317,7 +337,7 @@ msgstr "Hello, {$name}!""#;
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("nonexistent.po");
         let output_path = temp_dir.path().join("output.ftl");
-        
+
         // Try to convert non-existent file
         let result = po_to_fluent(&input_path, &output_path);
         assert!(result.is_err());
@@ -328,7 +348,7 @@ msgstr "Hello, {$name}!""#;
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("unclosed_select.ftl");
         let output_path = temp_dir.path().join("output.po");
-        
+
         // Test specific error: unclosed select expression
         let content = r#"hello = Hello World
 bad_plural = {$count ->
@@ -336,7 +356,7 @@ bad_plural = {$count ->
     # Missing closing brace
 "#;
         fs::write(&input_path, content).unwrap();
-        
+
         let result = fluent_to_po(&input_path, &output_path, "en", None);
         assert!(result.is_err(), "Should fail on unclosed select expression");
     }
@@ -346,13 +366,13 @@ bad_plural = {$count ->
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("mismatched_braces.ftl");
         let output_path = temp_dir.path().join("output.po");
-        
+
         // Test specific error: mismatched braces (opening { but closing with ])
         let content = r#"hello = Hello World
 greeting = Hello, {$name]!
 "#;
         fs::write(&input_path, content).unwrap();
-        
+
         let result = fluent_to_po(&input_path, &output_path, "en", None);
         assert!(result.is_err(), "Should fail on mismatched braces");
     }
@@ -362,13 +382,13 @@ greeting = Hello, {$name]!
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("invalid_key.ftl");
         let output_path = temp_dir.path().join("output.po");
-        
+
         // Test specific error: invalid attribute syntax (missing dot before attribute)
         let content = r#"button = Click me
 Button for clicking
 "#;
         fs::write(&input_path, content).unwrap();
-        
+
         let result = fluent_to_po(&input_path, &output_path, "en", None);
         assert!(result.is_err(), "Should fail on invalid attribute syntax");
     }
@@ -378,13 +398,16 @@ Button for clicking
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("invalid_structure.po");
         let output_path = temp_dir.path().join("output.ftl");
-        
+
         // Test specific error: binary/non-text file content that should fail parsing
         let content = b"\x00\x01\x02\xFF\xFE\x80\x90Binary data that is not valid text\x00\x00";
         fs::write(&input_path, content).unwrap();
-        
+
         let result = po_to_fluent(&input_path, &output_path);
-        assert!(result.is_err(), "Should fail on binary/invalid file content");
+        assert!(
+            result.is_err(),
+            "Should fail on binary/invalid file content"
+        );
     }
 
     #[test]
@@ -392,7 +415,7 @@ Button for clicking
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("invalid_escape.po");
         let output_path = temp_dir.path().join("output.ftl");
-        
+
         // Test specific error: invalid escape sequence
         let content = r#"msgid ""
 msgstr ""
@@ -403,7 +426,7 @@ msgid "Hello, \z invalid escape!"
 msgstr "Hello, world!"
 "#;
         fs::write(&input_path, content).unwrap();
-        
+
         let result = po_to_fluent(&input_path, &output_path);
         assert!(result.is_err(), "Should fail on invalid escape sequence");
     }
@@ -413,12 +436,12 @@ msgstr "Hello, world!"
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("malformed_msgid.po");
         let output_path = temp_dir.path().join("output.ftl");
-        
+
         // Test specific malformed PO content: broken msgid structure (missing quotes)
         // This causes polib to fail during metadata parsing
         let content = "msgid\nmsgstr \"test\"";
         fs::write(&input_path, content).unwrap();
-        
+
         let result = po_to_fluent(&input_path, &output_path);
         assert!(result.is_err(), "Should fail on broken msgid structure");
     }
@@ -446,21 +469,27 @@ msgctxt "application_passwords_not_supported"
 msgid "The site does not support Application Passwords."
 msgstr "O site não suporta Senhas de Aplicativo."
 "#;
-        
+
         fs::write(&input_path, problematic_po_content).unwrap();
-        
+
         // This should succeed with our preprocessing fallback mechanism
         let result = po_to_fluent(&input_path, &output_path);
-        
+
         match result {
             Ok(_) => {
                 // Verify the output contains expected content
                 let fluent_content = fs::read_to_string(&output_path).unwrap();
-                assert!(fluent_content.contains("parse_api_root_failure_reason_wordfence_blocking_access"));
+                assert!(
+                    fluent_content
+                        .contains("parse_api_root_failure_reason_wordfence_blocking_access")
+                );
                 assert!(fluent_content.contains("application_passwords_not_supported"));
             }
             Err(e) => {
-                panic!("Expected successful conversion with preprocessing fallback, but got error: {}", e);
+                panic!(
+                    "Expected successful conversion with preprocessing fallback, but got error: {}",
+                    e
+                );
             }
         }
     }
@@ -471,35 +500,35 @@ msgstr "O site não suporta Senhas de Aplicativo."
         let source_path = temp_dir.path().join("source.ftl");
         let target_path = temp_dir.path().join("target.ftl");
         let output_path = temp_dir.path().join("output.po");
-        
+
         // Create source language Fluent file (English)
         let source_content = r#"hello = Hello World
 greeting = Hello, {$name}!
 "#;
         fs::write(&source_path, source_content).unwrap();
-        
+
         // Create target language Fluent file (French)
         let target_content = r#"hello = Bonjour le monde
 greeting = Bonjour, {$name}!
 "#;
         fs::write(&target_path, target_content).unwrap();
-        
+
         // Convert target to PO with source language for msgid
         let result = fluent_to_po(&target_path, &output_path, "fr", Some(&source_path));
         assert!(result.is_ok());
-        
+
         // Verify PO file was created
         assert!(output_path.exists());
-        
+
         // Read the PO content and verify msgid contains source language text
         let po_content = fs::read_to_string(&output_path).unwrap();
-        
+
         // Check that msgid contains English text (source) and msgstr contains French text (target)
         assert!(po_content.contains("msgid \"Hello World\""));
         assert!(po_content.contains("msgstr \"Bonjour le monde\""));
         assert!(po_content.contains("msgid \"Hello, {$name}!\""));
         assert!(po_content.contains("msgstr \"Bonjour, {$name}!\""));
-        
+
         // Verify the msgctxt is present
         assert!(po_content.contains("msgctxt \"hello\""));
         assert!(po_content.contains("msgctxt \"greeting\""));
@@ -512,26 +541,24 @@ greeting = Bonjour, {$name}!
         let input_path = temp_dir.path().join("input.ftl");
         let po_path = temp_dir.path().join("output.po");
         let roundtrip_path = temp_dir.path().join("roundtrip.ftl");
-        
+
         // Create a simple Fluent file
         let fluent_content = r#"hello = Hello World
 greeting = Hello, {$name}!
 "#;
         fs::write(&input_path, fluent_content).unwrap();
-        
+
         // Convert Fluent to PO
         let result = fluent_to_po(&input_path, &po_path, "en", None);
         assert!(result.is_ok());
-        
+
         // Verify PO file was created
         assert!(po_path.exists());
-        
+
         // Most importantly, verify we can parse our own generated PO file
         // without any preprocessing (this would fail if required metadata is missing)
-        let direct_parse_result = std::panic::catch_unwind(|| {
-            polib::po_file::parse(&po_path)
-        });
-        
+        let direct_parse_result = std::panic::catch_unwind(|| polib::po_file::parse(&po_path));
+
         // This should succeed without panic or preprocessing
         match direct_parse_result {
             Ok(Ok(catalog)) => {
@@ -546,11 +573,11 @@ greeting = Hello, {$name}!
                 panic!("Generated PO file caused a panic - missing required metadata fields");
             }
         }
-        
+
         // Also test the round-trip conversion works
         let roundtrip_result = po_to_fluent(&po_path, &roundtrip_path);
         assert!(roundtrip_result.is_ok());
-        
+
         let roundtrip_content = fs::read_to_string(&roundtrip_path).unwrap();
         assert!(roundtrip_content.contains("hello = Hello World"));
         assert!(roundtrip_content.contains("greeting = Hello, { $name }!"));
@@ -563,7 +590,7 @@ greeting = Hello, {$name}!
         let input_path = temp_dir.path().join("input.ftl");
         let po_path = temp_dir.path().join("output.po");
         let roundtrip_path = temp_dir.path().join("roundtrip.ftl");
-        
+
         // Create a Fluent file with Russian plural forms (one, few, other)
         let fluent_content = r#"files = { $count ->
     [one] { $count } файл
@@ -572,25 +599,40 @@ greeting = Hello, {$name}!
 }
 "#;
         fs::write(&input_path, fluent_content).unwrap();
-        
+
         // Convert to PO with Russian locale
         let result = fluent_to_po(&input_path, &po_path, "ru", None);
         assert!(result.is_ok());
-        
+
         // Verify Russian plural forms in metadata
         let po_content = fs::read_to_string(&po_path).unwrap();
-        assert!(po_content.contains("nplurals=3"), "Should have 3 plural forms for Russian");
-        assert!(po_content.contains("Language: ru"), "Should specify Russian language");
-        
+        assert!(
+            po_content.contains("nplurals=3"),
+            "Should have 3 plural forms for Russian"
+        );
+        assert!(
+            po_content.contains("Language: ru"),
+            "Should specify Russian language"
+        );
+
         // Verify msgstr forms are ordered according to Russian CLDR: [one, few, other]
-        assert!(po_content.contains("msgstr[0] \"{$count} файл\""), "msgstr[0] should be 'one' form");
-        assert!(po_content.contains("msgstr[1] \"{$count} файла\""), "msgstr[1] should be 'few' form");
-        assert!(po_content.contains("msgstr[2] \"{$count} файлов\""), "msgstr[2] should be 'other' form");
-        
+        assert!(
+            po_content.contains("msgstr[0] \"{$count} файл\""),
+            "msgstr[0] should be 'one' form"
+        );
+        assert!(
+            po_content.contains("msgstr[1] \"{$count} файла\""),
+            "msgstr[1] should be 'few' form"
+        );
+        assert!(
+            po_content.contains("msgstr[2] \"{$count} файлов\""),
+            "msgstr[2] should be 'other' form"
+        );
+
         // Test round-trip conversion preserves ordering
         let roundtrip_result = po_to_fluent(&po_path, &roundtrip_path);
         assert!(roundtrip_result.is_ok());
-        
+
         let roundtrip_content = fs::read_to_string(&roundtrip_path).unwrap();
         assert!(roundtrip_content.contains("[one] { $count } файл"));
         assert!(roundtrip_content.contains("[few] { $count } файла"));
@@ -604,7 +646,7 @@ greeting = Hello, {$name}!
         let input_path = temp_dir.path().join("input.ftl");
         let po_path = temp_dir.path().join("output.po");
         let roundtrip_path = temp_dir.path().join("roundtrip.ftl");
-        
+
         // Create a Fluent file with Arabic plural forms (zero, one, two, few, many, other)
         let fluent_content = r#"items = { $count ->
     [zero] لا توجد عناصر
@@ -616,28 +658,52 @@ greeting = Hello, {$name}!
 }
 "#;
         fs::write(&input_path, fluent_content).unwrap();
-        
+
         // Convert to PO with Arabic locale
         let result = fluent_to_po(&input_path, &po_path, "ar", None);
         assert!(result.is_ok());
-        
+
         // Verify Arabic plural forms in metadata
         let po_content = fs::read_to_string(&po_path).unwrap();
-        assert!(po_content.contains("nplurals=6"), "Should have 6 plural forms for Arabic");
-        assert!(po_content.contains("Language: ar"), "Should specify Arabic language");
-        
+        assert!(
+            po_content.contains("nplurals=6"),
+            "Should have 6 plural forms for Arabic"
+        );
+        assert!(
+            po_content.contains("Language: ar"),
+            "Should specify Arabic language"
+        );
+
         // Verify msgstr forms are ordered according to Arabic CLDR: [zero, one, two, few, many, other]
-        assert!(po_content.contains("msgstr[0] \"لا توجد عناصر\""), "msgstr[0] should be 'zero' form");
-        assert!(po_content.contains("msgstr[1] \"عنصر واحد\""), "msgstr[1] should be 'one' form");
-        assert!(po_content.contains("msgstr[2] \"عنصران\""), "msgstr[2] should be 'two' form");
-        assert!(po_content.contains("msgstr[3] \"{$count} عناصر\""), "msgstr[3] should be 'few' form");
-        assert!(po_content.contains("msgstr[4] \"{$count} عنصراً\""), "msgstr[4] should be 'many' form");
-        assert!(po_content.contains("msgstr[5] \"{$count} عنصر\""), "msgstr[5] should be 'other' form");
-        
+        assert!(
+            po_content.contains("msgstr[0] \"لا توجد عناصر\""),
+            "msgstr[0] should be 'zero' form"
+        );
+        assert!(
+            po_content.contains("msgstr[1] \"عنصر واحد\""),
+            "msgstr[1] should be 'one' form"
+        );
+        assert!(
+            po_content.contains("msgstr[2] \"عنصران\""),
+            "msgstr[2] should be 'two' form"
+        );
+        assert!(
+            po_content.contains("msgstr[3] \"{$count} عناصر\""),
+            "msgstr[3] should be 'few' form"
+        );
+        assert!(
+            po_content.contains("msgstr[4] \"{$count} عنصراً\""),
+            "msgstr[4] should be 'many' form"
+        );
+        assert!(
+            po_content.contains("msgstr[5] \"{$count} عنصر\""),
+            "msgstr[5] should be 'other' form"
+        );
+
         // Test round-trip conversion preserves all forms
         let roundtrip_result = po_to_fluent(&po_path, &roundtrip_path);
         assert!(roundtrip_result.is_ok());
-        
+
         let roundtrip_content = fs::read_to_string(&roundtrip_path).unwrap();
         assert!(roundtrip_content.contains("[zero] لا توجد عناصر"));
         assert!(roundtrip_content.contains("[one] عنصر واحد"));
@@ -654,31 +720,37 @@ greeting = Hello, {$name}!
         let input_path = temp_dir.path().join("input.ftl");
         let po_path = temp_dir.path().join("output.po");
         let roundtrip_path = temp_dir.path().join("roundtrip.ftl");
-        
+
         // Create a Fluent file with Chinese plural (only 'other' form needed)
         let fluent_content = r#"items = { $count ->
    *[other] { $count } 个项目
 }
 "#;
         fs::write(&input_path, fluent_content).unwrap();
-        
+
         // Convert to PO with Chinese locale
         let result = fluent_to_po(&input_path, &po_path, "zh", None);
         assert!(result.is_ok());
-        
+
         // Verify Chinese plural forms in metadata
         let po_content = fs::read_to_string(&po_path).unwrap();
-        assert!(po_content.contains("nplurals=1"), "Should have 1 plural form for Chinese");
-        assert!(po_content.contains("Language: zh"), "Should specify Chinese language");
-        
+        assert!(
+            po_content.contains("nplurals=1"),
+            "Should have 1 plural form for Chinese"
+        );
+        assert!(
+            po_content.contains("Language: zh"),
+            "Should specify Chinese language"
+        );
+
         // Chinese should still generate msgstr[0] and msgstr[1] for PO compatibility
         assert!(po_content.contains("msgstr[0] \"{$count} 个项目\""));
         assert!(po_content.contains("msgstr[1] \"{$count} 个项目\""));
-        
+
         // Test round-trip conversion
         let roundtrip_result = po_to_fluent(&po_path, &roundtrip_path);
         assert!(roundtrip_result.is_ok());
-        
+
         let roundtrip_content = fs::read_to_string(&roundtrip_path).unwrap();
         assert!(roundtrip_content.contains("*[other] { $count } 个项目"));
     }
@@ -690,7 +762,7 @@ greeting = Hello, {$name}!
         let input_path = temp_dir.path().join("input.ftl");
         let po_path = temp_dir.path().join("output.po");
         let roundtrip_path = temp_dir.path().join("roundtrip.ftl");
-        
+
         // Create a Fluent file mixing numeric and CLDR categories
         let fluent_content = r#"notification = { $count ->
     [0] No notifications
@@ -700,24 +772,36 @@ greeting = Hello, {$name}!
 }
 "#;
         fs::write(&input_path, fluent_content).unwrap();
-        
+
         // Convert to PO with English locale
         let result = fluent_to_po(&input_path, &po_path, "en", None);
         assert!(result.is_ok());
-        
+
         let po_content = fs::read_to_string(&po_path).unwrap();
-        
+
         // Should prioritize CLDR categories first, then numeric forms
         // For English: [one, other] categories come first, then [0, 1] numeric forms
-        assert!(po_content.contains("msgstr[0] \"{$count} notification\""), "msgstr[0] should be CLDR 'one' form");
-        assert!(po_content.contains("msgstr[1] \"{$count} notifications\""), "msgstr[1] should be CLDR 'other' form");
-        assert!(po_content.contains("No notifications"), "Should include numeric '0' form");
-        assert!(po_content.contains("One notification"), "Should include numeric '1' form");
-        
+        assert!(
+            po_content.contains("msgstr[0] \"{$count} notification\""),
+            "msgstr[0] should be CLDR 'one' form"
+        );
+        assert!(
+            po_content.contains("msgstr[1] \"{$count} notifications\""),
+            "msgstr[1] should be CLDR 'other' form"
+        );
+        assert!(
+            po_content.contains("No notifications"),
+            "Should include numeric '0' form"
+        );
+        assert!(
+            po_content.contains("One notification"),
+            "Should include numeric '1' form"
+        );
+
         // Test round-trip conversion preserves all forms
         let roundtrip_result = po_to_fluent(&po_path, &roundtrip_path);
         assert!(roundtrip_result.is_ok());
-        
+
         let roundtrip_content = fs::read_to_string(&roundtrip_path).unwrap();
         assert!(roundtrip_content.contains("notification ="));
         assert!(roundtrip_content.contains("{ $count ->"));
@@ -729,7 +813,7 @@ greeting = Hello, {$name}!
         let temp_dir = tempdir().unwrap();
         let input_path = temp_dir.path().join("input.ftl");
         let po_path = temp_dir.path().join("output.po");
-        
+
         // Create a Fluent file with plurals
         let fluent_content = r#"days = { $count ->
     [one] { $count } dia
@@ -737,20 +821,35 @@ greeting = Hello, {$name}!
 }
 "#;
         fs::write(&input_path, fluent_content).unwrap();
-        
+
         // Convert to PO with Brazilian Portuguese locale (should use Portuguese rules)
         let result = fluent_to_po(&input_path, &po_path, "pt-BR", None);
         assert!(result.is_ok());
-        
+
         let po_content = fs::read_to_string(&po_path).unwrap();
-        
+
         // Should use Portuguese plural rules (nplurals=2; plural=(n > 1))
-        assert!(po_content.contains("nplurals=2"), "Should have 2 plural forms for Portuguese");
-        assert!(po_content.contains("plural=(n > 1)"), "Should use Portuguese plural rule");
-        assert!(po_content.contains("Language: pt-BR"), "Should preserve full locale code");
-        
+        assert!(
+            po_content.contains("nplurals=2"),
+            "Should have 2 plural forms for Portuguese"
+        );
+        assert!(
+            po_content.contains("plural=(n > 1)"),
+            "Should use Portuguese plural rule"
+        );
+        assert!(
+            po_content.contains("Language: pt-BR"),
+            "Should preserve full locale code"
+        );
+
         // Verify correct ordering (Portuguese uses same categories as English: one, other)
-        assert!(po_content.contains("msgstr[0] \"{$count} dia\""), "msgstr[0] should be 'one' form");
-        assert!(po_content.contains("msgstr[1] \"{$count} dias\""), "msgstr[1] should be 'other' form");
+        assert!(
+            po_content.contains("msgstr[0] \"{$count} dia\""),
+            "msgstr[0] should be 'one' form"
+        );
+        assert!(
+            po_content.contains("msgstr[1] \"{$count} dias\""),
+            "msgstr[1] should be 'other' form"
+        );
     }
 }

--- a/src/po/mod.rs
+++ b/src/po/mod.rs
@@ -1,5 +1,5 @@
-pub mod po_format;
-pub mod converter;
 pub mod cldr_plural_rules;
+pub mod converter;
+pub mod po_format;
 
 pub use converter::{fluent_to_po, po_to_fluent};

--- a/src/po/po_format.rs
+++ b/src/po/po_format.rs
@@ -1,22 +1,21 @@
-use polib::po_file;
 use polib::catalog::Catalog;
-use polib::metadata::CatalogMetadata;
 use polib::message::{Message as PoMessage, MessageView};
+use polib::metadata::CatalogMetadata;
+use polib::po_file;
 
-use anyhow::Result;
-use std::path::Path;
-use crate::shared::fluent_data::{FluentResource, FluentMessage, FluentPattern, FluentElement, extract_pattern_text, parse_string_value_as_fluent_pattern};
-use crate::shared::error::ConversionError;
 use crate::po::cldr_plural_rules::{
-    get_plural_forms_for_locale,
-    map_cldr_categories_to_po_indices_for_locale, 
-    map_po_indices_to_cldr_categories_for_locale, 
-    is_singular_category,
-    is_other_category,
-    CLDR_OTHER_CATEGORY,
-    DEFAULT_PLURAL_FORMS,
+    CLDR_OTHER_CATEGORY, DEFAULT_PLURAL_FORMS, get_plural_forms_for_locale, is_other_category,
+    is_singular_category, map_cldr_categories_to_po_indices_for_locale,
+    map_po_indices_to_cldr_categories_for_locale,
 };
+use crate::shared::error::ConversionError;
+use crate::shared::fluent_data::{
+    FluentElement, FluentMessage, FluentPattern, FluentResource, extract_pattern_text,
+    parse_string_value_as_fluent_pattern,
+};
+use anyhow::Result;
 use std::collections::HashMap;
+use std::path::Path;
 
 // =============================================================================
 // Constants
@@ -24,7 +23,7 @@ use std::collections::HashMap;
 
 const REQUIRED_METADATA_FIELDS: &[&str] = &[
     "Project-Id-Version",
-    "POT-Creation-Date", 
+    "POT-Creation-Date",
     "PO-Revision-Date",
     "Last-Translator",
     "Language-Team",
@@ -49,19 +48,22 @@ const FLUENT_SELECTOR_PREFIX: &str = "FLUENT_SELECTOR:";
 pub fn parse_po_file(input_path: &Path) -> Result<Catalog> {
     let content = std::fs::read_to_string(input_path)?;
     let preprocessed_content = preprocess_po_content(&content)?;
-    
+
     // Write preprocessed content to temporary file for parsing
     let temp_file = tempfile::NamedTempFile::new()?;
     std::fs::write(temp_file.path(), preprocessed_content)?;
-    
+
     // Catch panics from malformed PO content that might cause polib to panic
-    let parse_result = std::panic::catch_unwind(|| {
-        po_file::parse(temp_file.path())
-    });
-    
+    let parse_result = std::panic::catch_unwind(|| po_file::parse(temp_file.path()));
+
     match parse_result {
-        Ok(result) => result.map_err(|e| ConversionError::InputFileParseError(format!("Failed to parse PO file: {}", e)).into()),
-        Err(_) => Err(ConversionError::InputFileParseError("Failed to parse PO file: malformed content caused parser panic".to_string()).into())
+        Ok(result) => result.map_err(|e| {
+            ConversionError::InputFileParseError(format!("Failed to parse PO file: {}", e)).into()
+        }),
+        Err(_) => Err(ConversionError::InputFileParseError(
+            "Failed to parse PO file: malformed content caused parser panic".to_string(),
+        )
+        .into()),
     }
 }
 
@@ -73,44 +75,44 @@ pub fn preprocess_po_content(content: &str) -> Result<String> {
 
 /// Convert a Fluent resource to a PO catalog
 pub fn fluent_to_po_catalog(
-    target_resource: FluentResource, 
-    locale: &str, 
-    source_resource: Option<FluentResource>
+    target_resource: FluentResource,
+    locale: &str,
+    source_resource: Option<FluentResource>,
 ) -> Result<Catalog> {
     let metadata = create_po_metadata(locale);
     let mut catalog = Catalog::new(metadata);
-    
+
     let source_lookup = create_source_message_lookup(source_resource.as_ref());
-    
+
     for message in target_resource.messages {
         let source_message = source_lookup.get(&message.id).copied();
         convert_fluent_message_to_po(&mut catalog, &message, source_message, locale)?;
     }
-    
+
     Ok(catalog)
 }
 
 /// Convert a PO catalog to FluentResource
 pub fn po_catalog_to_fluent(catalog: Catalog) -> Result<FluentResource> {
     let mut fluent_messages = Vec::new();
-    
+
     // Convert each PO message to Fluent message
     for message in catalog.messages() {
         let key = generate_fluent_key_from_message(message);
-        
+
         // Convert PO message to Fluent message
         let fluent_message = if message.is_plural() {
             convert_plural_po_message_to_fluent_message(&key, message, &catalog.metadata.language)?
         } else {
             convert_singular_po_message_to_fluent_message(&key, message)?
         };
-        
+
         // Skip empty messages (untranslated entries)
         if let Some(fluent_message) = fluent_message {
             fluent_messages.push(fluent_message);
         }
     }
-    
+
     Ok(FluentResource {
         messages: fluent_messages,
     })
@@ -139,7 +141,7 @@ impl<'a> PoContentProcessor<'a> {
             header_lines: Vec::new(),
         }
     }
-    
+
     fn process(&mut self) -> Result<String> {
         let lines = self.lines.clone();
         for line in &lines {
@@ -147,7 +149,7 @@ impl<'a> PoContentProcessor<'a> {
         }
         Ok(self.result.join("\n"))
     }
-    
+
     fn process_line(&mut self, line: &str) {
         match line.trim() {
             "msgid \"\"" => self.start_header_section(line),
@@ -155,12 +157,12 @@ impl<'a> PoContentProcessor<'a> {
             _ => self.handle_other_line(line),
         }
     }
-    
+
     fn start_header_section(&mut self, line: &str) {
         self.header_section = true;
         self.add_header_line(line);
     }
-    
+
     fn handle_other_line(&mut self, line: &str) {
         if self.header_section && self.is_metadata_line(line) {
             self.process_metadata_line(line);
@@ -171,43 +173,44 @@ impl<'a> PoContentProcessor<'a> {
             self.add_line(line);
         }
     }
-    
+
     fn is_metadata_line(&self, line: &str) -> bool {
         line.starts_with('"') && line.ends_with('"')
     }
-    
+
     fn is_end_of_header(&self, line: &str) -> bool {
         !line.starts_with('"') || line.trim().is_empty()
     }
-    
+
     fn process_metadata_line(&mut self, line: &str) {
         self.header_lines.push(line.to_string());
-        
+
         if let Some(colon_pos) = line.find(':') {
             let field_name = &line[1..colon_pos]; // Remove starting quote
             self.found_metadata.insert(field_name.to_string(), true);
         }
     }
-    
+
     fn finalize_header(&mut self) {
         self.header_section = false;
         self.add_missing_metadata_fields();
         self.result.extend(self.header_lines.drain(..));
     }
-    
+
     fn add_missing_metadata_fields(&mut self) {
         for &field in REQUIRED_METADATA_FIELDS {
             if !self.found_metadata.contains_key(field) {
                 let default_value = get_default_metadata_value(field);
-                self.header_lines.push(format!("\"{}: {}\\n\"", field, default_value));
+                self.header_lines
+                    .push(format!("\"{}: {}\\n\"", field, default_value));
             }
         }
     }
-    
+
     fn add_line(&mut self, line: &str) {
         self.result.push(line.to_string());
     }
-    
+
     fn add_header_line(&mut self, line: &str) {
         self.header_lines.push(line.to_string());
     }
@@ -225,19 +228,19 @@ struct PluralInfo {
 // =============================================================================
 
 fn convert_fluent_message_to_po(
-    catalog: &mut Catalog, 
-    message: &FluentMessage, 
+    catalog: &mut Catalog,
+    message: &FluentMessage,
     source_message: Option<&FluentMessage>,
-    locale: &str
+    locale: &str,
 ) -> Result<()> {
     // Convert main message value
     if let Some(pattern) = &message.value {
         convert_main_message_value(catalog, message, pattern, source_message, locale)?;
     }
-    
+
     // Convert attributes
     convert_message_attributes(catalog, message, source_message)?;
-    
+
     Ok(())
 }
 
@@ -250,13 +253,20 @@ fn convert_main_message_value(
 ) -> Result<()> {
     let target_text = extract_pattern_text(pattern);
     let comments = message.comment.as_ref().unwrap_or(&String::new()).clone();
-    
+
     if let Some(plural_info) = extract_plural_info(pattern) {
-        convert_plural_message(catalog, message, &plural_info, source_message, &comments, locale)?;
+        convert_plural_message(
+            catalog,
+            message,
+            &plural_info,
+            source_message,
+            &comments,
+            locale,
+        )?;
     } else {
         convert_singular_message(catalog, message, &target_text, source_message, &comments)?;
     }
-    
+
     Ok(())
 }
 
@@ -274,7 +284,8 @@ fn convert_plural_message(
         if let Some(source_value) = &source_msg.value {
             if let Some(source_plural_info) = extract_plural_info(source_value) {
                 // Use source for msgid, target for msgstr
-                let (source_msgid, source_msgid_plural, _) = create_po_plural_forms(&source_plural_info, locale);
+                let (source_msgid, source_msgid_plural, _) =
+                    create_po_plural_forms(&source_plural_info, locale);
                 let (_, _, target_msgstr_forms) = create_po_plural_forms(plural_info, locale);
                 (source_msgid, source_msgid_plural, target_msgstr_forms)
             } else {
@@ -289,19 +300,19 @@ fn convert_plural_message(
         // No source message, use target for both
         create_po_plural_forms(plural_info, locale)
     };
-    
+
     let mut msg_builder = PoMessage::build_plural();
     msg_builder
         .with_msgctxt(message.id.clone())
         .with_msgid(msgid)
         .with_msgid_plural(msgid_plural)
         .with_msgstr_plural(msgstr_forms);
-            
+
     let combined_comments = create_combined_comments(comments, &plural_info.selector);
     if !combined_comments.is_empty() {
         msg_builder.with_comments(combined_comments);
     }
-    
+
     catalog.append_or_update(msg_builder.done());
     Ok(())
 }
@@ -314,17 +325,17 @@ fn convert_singular_message(
     comments: &str,
 ) -> Result<()> {
     let msgid = get_source_text_or_target(source_message, target_text);
-    
-            let mut msg_builder = PoMessage::build_singular();
-            msg_builder
+
+    let mut msg_builder = PoMessage::build_singular();
+    msg_builder
         .with_msgctxt(message.id.clone())
         .with_msgid(msgid)
         .with_msgstr(target_text.to_string());
-    
+
     if !comments.is_empty() {
         msg_builder.with_comments(comments.to_string());
     }
-    
+
     catalog.append_or_update(msg_builder.done());
     Ok(())
 }
@@ -337,43 +348,43 @@ fn convert_message_attributes(
     for (attr_name, attr_pattern) in &message.attributes {
         let attr_msgctxt = format!("{}.{}", message.id, attr_name);
         let target_attr_text = extract_pattern_text(attr_pattern);
-        
+
         let source_attr_text = source_message
             .and_then(|sm| sm.attributes.get(attr_name))
             .map(|sp| extract_pattern_text(sp));
-        
+
         let msgid = source_attr_text.unwrap_or_else(|| target_attr_text.clone());
-        
+
         let mut msg_builder = PoMessage::build_singular();
         msg_builder
             .with_msgctxt(attr_msgctxt)
             .with_msgid(msgid)
             .with_msgstr(target_attr_text);
-        
+
         catalog.append_or_update(msg_builder.done());
     }
-    
+
     Ok(())
 }
 
 fn convert_singular_po_message_to_fluent_message(
-    key: &str, 
-    message: &dyn MessageView
+    key: &str,
+    message: &dyn MessageView,
 ) -> Result<Option<FluentMessage>> {
     let msgstr = message.msgstr()?;
-    
+
     // Skip entries with empty msgstr values as they represent untranslated strings
     if msgstr.trim().is_empty() {
         return Ok(None);
     }
-    
+
     // Simply try to parse the unescaped content as a Fluent message value
     let unescaped_msgstr = unescape_fluent_value(&msgstr);
     let pattern = parse_string_value_as_fluent_pattern(key, &unescaped_msgstr);
-    
+
     // Extract comments (excluding FLUENT_SELECTOR comments which are handled separately)
     let comment = extract_filtered_comments(message.comments());
-    
+
     Ok(Some(FluentMessage {
         id: key.to_string(),
         value: Some(pattern),
@@ -383,28 +394,28 @@ fn convert_singular_po_message_to_fluent_message(
 }
 
 fn convert_plural_po_message_to_fluent_message(
-    key: &str, 
+    key: &str,
     message: &dyn MessageView,
-    locale: &str
+    locale: &str,
 ) -> Result<Option<FluentMessage>> {
     let msgstr_plural = message.msgstr_plural()?;
-    let selector = extract_selector_from_comments(message.comments())
-        .unwrap_or_else(|| "count".to_string());
-    
+    let selector =
+        extract_selector_from_comments(message.comments()).unwrap_or_else(|| "count".to_string());
+
     // Build variants directly using Fluent structures
     let mut variants = HashMap::new();
     let mut has_other = false;
-    
+
     // Map standard PO msgstr[n] entries to Fluent plural forms using CLDR mapping
     let cldr_categories = map_po_indices_to_cldr_categories_for_locale(msgstr_plural.len(), locale);
-    
+
     for (index, msgstr) in msgstr_plural.iter().enumerate() {
         let cleaned_msgstr = unescape_fluent_value(msgstr);
-        
+
         if !cleaned_msgstr.trim().is_empty() {
             // Parse each variant text as a Fluent pattern
             let variant_pattern = parse_string_value_as_fluent_pattern(key, &cleaned_msgstr);
-            
+
             // Map PO plural index to Fluent variant key using CLDR categories
             let variant_key = if index < cldr_categories.len() {
                 let cldr_key = cldr_categories[index];
@@ -416,11 +427,11 @@ fn convert_plural_po_message_to_fluent_message(
                 // Additional forms for complex languages - use numeric fallback
                 format!("{}", index)
             };
-            
+
             variants.insert(variant_key, variant_pattern);
         }
     }
-    
+
     // Ensure we have at least an 'other' form (required by Fluent)
     if !has_other && !variants.is_empty() {
         // If we don't have an explicit "other" form, use the last available form
@@ -431,25 +442,28 @@ fn convert_plural_po_message_to_fluent_message(
             }
         }
     }
-    
+
     if !has_other {
         let fallback_text = message.msgid_plural().unwrap_or("items");
-        variants.insert(CLDR_OTHER_CATEGORY.to_string(), FluentPattern {
-            elements: vec![FluentElement::Text(fallback_text.to_string())],
-        });
+        variants.insert(
+            CLDR_OTHER_CATEGORY.to_string(),
+            FluentPattern {
+                elements: vec![FluentElement::Text(fallback_text.to_string())],
+            },
+        );
     }
-    
+
     if variants.is_empty() {
         return Ok(None);
     }
-    
+
     // Create the plural pattern directly using Fluent structures
     let pattern = FluentPattern {
         elements: vec![FluentElement::Plural { selector, variants }],
     };
-    
+
     let comment = extract_filtered_comments(message.comments());
-    
+
     Ok(Some(FluentMessage {
         id: key.to_string(),
         value: Some(pattern),
@@ -463,12 +477,12 @@ fn extract_filtered_comments(comments: &str) -> Option<String> {
     if comments.is_empty() {
         return None;
     }
-    
+
     let filtered_comments: Vec<&str> = comments
         .lines()
         .filter(|line| !line.trim().starts_with(FLUENT_SELECTOR_PREFIX))
         .collect();
-    
+
     if filtered_comments.is_empty() {
         None
     } else {
@@ -484,12 +498,12 @@ fn create_po_metadata(locale: &str) -> CatalogMetadata {
     let project_id_version = option_env!("CARGO_PKG_VERSION")
         .map(|v| format!("wordpress-rs {}", v))
         .unwrap_or_else(|| "wordpress-rs".to_string());
-    
+
     let now = chrono::Local::now().format("%Y-%m-%d %H:%M%z").to_string();
-    
+
     // Get the correct CLDR plural forms for the locale
     let plural_forms = get_plural_forms_for_locale(locale);
-    
+
     // Construct the metadata string with proper plural forms
     let metadata_str = format!(
         "Project-Id-Version: {}\n\
@@ -511,15 +525,21 @@ fn create_po_metadata(locale: &str) -> CatalogMetadata {
         locale,
         plural_forms
     );
-    
+
     // Parse the metadata string to create CatalogMetadata with proper plural rules
-    CatalogMetadata::parse(&metadata_str)
-        .expect("Failed to parse metadata string")
+    CatalogMetadata::parse(&metadata_str).expect("Failed to parse metadata string")
 }
 
-fn create_source_message_lookup(source_resource: Option<&FluentResource>) -> HashMap<String, &FluentMessage> {
+fn create_source_message_lookup(
+    source_resource: Option<&FluentResource>,
+) -> HashMap<String, &FluentMessage> {
     source_resource
-        .map(|sr| sr.messages.iter().map(|msg| (msg.id.clone(), msg)).collect())
+        .map(|sr| {
+            sr.messages
+                .iter()
+                .map(|msg| (msg.id.clone(), msg))
+                .collect()
+        })
         .unwrap_or_default()
 }
 
@@ -538,7 +558,8 @@ fn generate_fluent_key_from_message(message: &dyn MessageView) -> String {
     if !message.msgctxt().is_empty() {
         message.msgctxt().to_string()
     } else {
-        message.msgid()
+        message
+            .msgid()
             .replace(' ', "-")
             .replace('"', "")
             .to_lowercase()
@@ -554,7 +575,7 @@ fn get_source_text_or_target(source_message: Option<&FluentMessage>, target_text
 
 fn create_combined_comments(existing_comments: &str, selector: &str) -> String {
     let selector_comment = format!("{}{}", FLUENT_SELECTOR_PREFIX, selector);
-    
+
     if existing_comments.is_empty() {
         selector_comment
     } else {
@@ -568,15 +589,15 @@ fn extract_plural_info(pattern: &FluentPattern) -> Option<PluralInfo> {
             let forms: Vec<(String, String)> = variants
                 .iter()
                 .map(|(key, variant_pattern)| {
-                let text = extract_pattern_text(variant_pattern);
+                    let text = extract_pattern_text(variant_pattern);
                     (key.clone(), text)
                 })
                 .collect();
-            
+
             if !forms.is_empty() {
-                return Some(PluralInfo { 
+                return Some(PluralInfo {
                     selector: selector.clone(),
-                    forms 
+                    forms,
                 });
             }
         }
@@ -587,23 +608,24 @@ fn extract_plural_info(pattern: &FluentPattern) -> Option<PluralInfo> {
 fn create_po_plural_forms(plural_info: &PluralInfo, locale: &str) -> (String, String, Vec<String>) {
     // Use CLDR mapping for msgstr forms (already implemented and working well)
     let msgstr_forms = map_cldr_categories_to_po_indices_for_locale(&plural_info.forms, locale);
-    
+
     // Simplified msgid/msgid_plural selection logic
     let msgid = find_singular_form(&plural_info.forms);
     let msgid_plural = find_plural_form(&plural_info.forms);
-    
+
     (msgid, msgid_plural, msgstr_forms)
 }
 
 // Simplified helper functions for picking msgid/msgid_plural from Fluent forms
 fn find_singular_form(forms: &[(String, String)]) -> String {
     // Look for standard singular forms in order of preference
-    if let Some((_, text)) = forms.iter().find(|(key, _)|  is_singular_category(key)) {
+    if let Some((_, text)) = forms.iter().find(|(key, _)| is_singular_category(key)) {
         return text.clone();
     }
-    
+
     // Fallback to first available form
-    forms.first()
+    forms
+        .first()
         .map(|(_, text)| text.clone())
         .unwrap_or_default()
 }
@@ -613,14 +635,15 @@ fn find_plural_form(forms: &[(String, String)]) -> String {
     if let Some((_, text)) = forms.iter().find(|(key, _)| is_other_category(key)) {
         return text.clone();
     }
-    
+
     // Find any form that's not singular
     if let Some((_, text)) = forms.iter().find(|(key, _)| !is_singular_category(key)) {
         return text.clone();
     }
-    
+
     // Final fallback - use second form if available, otherwise first
-    forms.get(1)
+    forms
+        .get(1)
         .or_else(|| forms.first())
         .map(|(_, text)| text.clone())
         .unwrap_or_default()
@@ -653,19 +676,25 @@ mod tests {
     fn test_fluent_to_po_catalog() {
         // Test both simple and complex messages in one test
         let mut variants = HashMap::new();
-        variants.insert("one".to_string(), FluentPattern {
-            elements: vec![
-                FluentElement::Variable("count".to_string()),
-                FluentElement::Text(" item".to_string()),
-            ],
-        });
-        variants.insert("other".to_string(), FluentPattern {
-            elements: vec![
-                FluentElement::Variable("count".to_string()),
-                FluentElement::Text(" items".to_string()),
-            ],
-        });
-        
+        variants.insert(
+            "one".to_string(),
+            FluentPattern {
+                elements: vec![
+                    FluentElement::Variable("count".to_string()),
+                    FluentElement::Text(" item".to_string()),
+                ],
+            },
+        );
+        variants.insert(
+            "other".to_string(),
+            FluentPattern {
+                elements: vec![
+                    FluentElement::Variable("count".to_string()),
+                    FluentElement::Text(" items".to_string()),
+                ],
+            },
+        );
+
         let fluent_messages = vec![
             // Simple message
             FluentMessage {
@@ -702,23 +731,26 @@ mod tests {
                 comment: Some("Item counter".to_string()),
             },
         ];
-        
+
         let fluent_resource = FluentResource {
             messages: fluent_messages,
         };
-        
+
         let result = fluent_to_po_catalog(fluent_resource, "en", None);
         assert!(result.is_ok());
-        
+
         let catalog = result.unwrap();
         assert_eq!(catalog.messages().count(), 3);
-        
+
         // Check metadata
         assert_eq!(catalog.metadata.language, "en");
         assert_eq!(catalog.metadata.content_type, DEFAULT_CHARSET);
-        
+
         // Verify plural message
-        let plural_message = catalog.messages().find(|m| m.msgctxt() == "item_count").unwrap();
+        let plural_message = catalog
+            .messages()
+            .find(|m| m.msgctxt() == "item_count")
+            .unwrap();
         assert!(plural_message.is_plural());
         assert!(plural_message.comments().contains("FLUENT_SELECTOR:count"));
     }
@@ -729,7 +761,7 @@ mod tests {
         let mut metadata = CatalogMetadata::default();
         metadata.language = "en".to_string();
         let mut catalog = Catalog::new(metadata);
-        
+
         // Simple message
         let mut msg_builder = PoMessage::build_singular();
         msg_builder
@@ -738,7 +770,7 @@ mod tests {
             .with_msgstr("Hello World".to_string())
             .with_comments("A simple greeting".to_string());
         catalog.append_or_update(msg_builder.done());
-        
+
         // Plural message using standard PO format (no FLUENT_ markers)
         let mut msg_builder = PoMessage::build_plural();
         msg_builder
@@ -751,15 +783,15 @@ mod tests {
             ])
             .with_comments("FLUENT_SELECTOR:count\nItem counter".to_string());
         catalog.append_or_update(msg_builder.done());
-        
+
         let result = po_catalog_to_fluent(catalog);
         assert!(result.is_ok());
-        
+
         let fluent_resource = result.unwrap();
-        
+
         // Convert to string for testing using the same logic as converter.rs
         let fluent_content = fluent_resource.to_source();
-        
+
         assert!(fluent_content.contains("# A simple greeting"));
         assert!(fluent_content.contains("hello = Hello World"));
         assert!(fluent_content.contains("item_count ="));
@@ -773,34 +805,40 @@ mod tests {
     fn test_extract_plural_info() {
         // Test with a plural pattern
         let mut variants = HashMap::new();
-        variants.insert("one".to_string(), FluentPattern {
-            elements: vec![FluentElement::Text("one item".to_string())],
-        });
-        variants.insert("other".to_string(), FluentPattern {
-            elements: vec![FluentElement::Text("many items".to_string())],
-        });
-        
+        variants.insert(
+            "one".to_string(),
+            FluentPattern {
+                elements: vec![FluentElement::Text("one item".to_string())],
+            },
+        );
+        variants.insert(
+            "other".to_string(),
+            FluentPattern {
+                elements: vec![FluentElement::Text("many items".to_string())],
+            },
+        );
+
         let pattern = FluentPattern {
             elements: vec![FluentElement::Plural {
                 selector: "count".to_string(),
                 variants,
             }],
         };
-        
+
         let plural_info = extract_plural_info(&pattern);
         assert!(plural_info.is_some());
-        
+
         let info = plural_info.unwrap();
         assert_eq!(info.selector, "count");
         assert_eq!(info.forms.len(), 2);
         assert!(info.forms.iter().any(|(key, _)| key == "one"));
         assert!(info.forms.iter().any(|(key, _)| key == "other"));
-        
+
         // Test with a simple pattern (no plurals)
         let simple_pattern = FluentPattern {
             elements: vec![FluentElement::Text("Hello World".to_string())],
         };
-        
+
         let plural_info = extract_plural_info(&simple_pattern);
         assert!(plural_info.is_none());
     }
@@ -815,16 +853,16 @@ mod tests {
                 ("other".to_string(), "{$count} items".to_string()),
             ],
         };
-        
+
         let (msgid, msgid_plural, msgstr_forms) = create_po_plural_forms(&plural_info, "en");
-        
+
         assert_eq!(msgid, "{$count} item");
         assert_eq!(msgid_plural, "{$count} items");
         assert_eq!(msgstr_forms.len(), 2);
         // New standard PO format without FLUENT_ markers
         assert!(msgstr_forms.contains(&"{$count} item".to_string()));
         assert!(msgstr_forms.contains(&"{$count} items".to_string()));
-        
+
         // Test with numeric forms
         let plural_info_numeric = PluralInfo {
             selector: "count".to_string(),
@@ -834,9 +872,10 @@ mod tests {
                 ("other".to_string(), "many items".to_string()),
             ],
         };
-        
-        let (msgid, msgid_plural, msgstr_forms) = create_po_plural_forms(&plural_info_numeric, "en");
-        
+
+        let (msgid, msgid_plural, msgstr_forms) =
+            create_po_plural_forms(&plural_info_numeric, "en");
+
         assert_eq!(msgid, "one item");
         assert_eq!(msgid_plural, "many items");
         assert!(msgstr_forms.len() >= 2);
@@ -850,11 +889,11 @@ mod tests {
         let comments = "This is a test\nFLUENT_SELECTOR:count\nAnother line";
         let selector = extract_selector_from_comments(comments);
         assert_eq!(selector, Some("count".to_string()));
-        
+
         let comments_no_selector = "This is a test\nAnother line";
         let selector = extract_selector_from_comments(comments_no_selector);
         assert_eq!(selector, None);
-        
+
         let comments_with_spaces = "FLUENT_SELECTOR:  item_count  ";
         let selector = extract_selector_from_comments(comments_with_spaces);
         assert_eq!(selector, Some("item_count".to_string()));
@@ -863,7 +902,10 @@ mod tests {
     #[test]
     fn test_unescape_fluent_value() {
         assert_eq!(unescape_fluent_value("Hello \\{name\\}"), "Hello {name}");
-        assert_eq!(unescape_fluent_value("Path\\\\to\\\\file"), "Path\\to\\file");
+        assert_eq!(
+            unescape_fluent_value("Path\\\\to\\\\file"),
+            "Path\\to\\file"
+        );
         assert_eq!(unescape_fluent_value("Normal text"), "Normal text");
         assert_eq!(unescape_fluent_value("\\{$var\\} text"), "{$var} text");
     }
@@ -872,37 +914,37 @@ mod tests {
     fn test_write_and_parse_po_file() {
         let temp_dir = tempdir().unwrap();
         let po_path = temp_dir.path().join("test.po");
-        
+
         // Create a catalog
         let mut metadata = CatalogMetadata::default();
         metadata.language = "en".to_string();
         metadata.content_type = DEFAULT_CHARSET.to_string();
-        
+
         let mut catalog = Catalog::new(metadata);
-        
+
         let mut msg_builder = PoMessage::build_singular();
         msg_builder
             .with_msgctxt("test".to_string())
             .with_msgid("Test message".to_string())
             .with_msgstr("Test message".to_string());
-        
+
         let message = msg_builder.done();
         catalog.append_or_update(message);
-        
+
         // Write the file
         let write_result = po_file::write(&catalog, &po_path);
         assert!(write_result.is_ok());
-        
+
         // Verify file exists
         assert!(po_path.exists());
-        
+
         // Parse it back
         let parse_result = parse_po_file(&po_path);
         assert!(parse_result.is_ok());
-        
+
         let parsed_catalog = parse_result.unwrap();
         assert_eq!(parsed_catalog.messages().count(), 1);
-        
+
         let parsed_message = parsed_catalog.messages().next().unwrap();
         assert_eq!(parsed_message.msgctxt(), "test");
         assert_eq!(parsed_message.msgid(), "Test message");
@@ -914,9 +956,9 @@ mod tests {
         let mut metadata = CatalogMetadata::default();
         metadata.language = "en".to_string();
         metadata.content_type = "text/plain; charset=UTF-8".to_string();
-        
+
         let mut catalog = Catalog::new(metadata);
-        
+
         // Add message with empty msgstr
         let mut msg_builder = PoMessage::build_singular();
         msg_builder
@@ -924,7 +966,7 @@ mod tests {
             .with_msgid("source text".to_string())
             .with_msgstr("".to_string());
         catalog.append_or_update(msg_builder.done());
-        
+
         // Add message with whitespace-only msgstr
         let mut msg_builder = PoMessage::build_singular();
         msg_builder
@@ -932,7 +974,7 @@ mod tests {
             .with_msgid("source text 2".to_string())
             .with_msgstr("   ".to_string());
         catalog.append_or_update(msg_builder.done());
-        
+
         // Add valid translated messages to test line handling
         let mut msg_builder = PoMessage::build_singular();
         msg_builder
@@ -940,35 +982,35 @@ mod tests {
             .with_msgid("first message".to_string())
             .with_msgstr("translated first".to_string());
         catalog.append_or_update(msg_builder.done());
-        
+
         let mut msg_builder = PoMessage::build_singular();
         msg_builder
             .with_msgctxt("second".to_string())
             .with_msgid("second message".to_string())
             .with_msgstr("translated second".to_string());
         catalog.append_or_update(msg_builder.done());
-        
+
         // Convert to Fluent
         let result = po_catalog_to_fluent(catalog);
         assert!(result.is_ok());
-        
+
         let fluent_resource = result.unwrap();
-        
+
         // Convert to string for testing
         let fluent_content = fluent_resource.to_source();
-        
+
         // Empty and whitespace-only entries should be omitted
         assert!(!fluent_content.contains("empty-key"));
         assert!(!fluent_content.contains("whitespace-key"));
-        
+
         // Valid entries should be present
         assert!(fluent_content.contains("first = translated first"));
         assert!(fluent_content.contains("second = translated second"));
-        
+
         // Should not contain any invalid "key = " entries
         assert!(!fluent_content.contains("= \n"));
         assert!(!fluent_content.contains("=  "));
-        
+
         // Check that messages are present (the formatting is now handled in converter.rs)
         assert_eq!(fluent_resource.messages.len(), 2);
     }
@@ -979,9 +1021,9 @@ mod tests {
         let mut metadata = CatalogMetadata::default();
         metadata.language = "en".to_string();
         metadata.content_type = "text/plain; charset=UTF-8".to_string();
-        
+
         let mut catalog = Catalog::new(metadata);
-        
+
         // Add multiline message
         let mut msg_builder = PoMessage::build_singular();
         msg_builder
@@ -989,26 +1031,29 @@ mod tests {
             .with_msgid("Multi line source".to_string())
             .with_msgstr("This is line one\nThis is line two\nThis is line three".to_string());
         catalog.append_or_update(msg_builder.done());
-        
+
         // Convert to Fluent
         let result = po_catalog_to_fluent(catalog);
         assert!(result.is_ok());
-        
+
         let fluent_resource = result.unwrap();
-        
+
         // Convert to string and verify proper multiline formatting
         let fluent_content = fluent_resource.to_source();
-        
+
         // The message should be formatted with proper indentation
         assert!(fluent_content.contains("multiline-message ="));
         assert!(fluent_content.contains("This is line one"));
         assert!(fluent_content.contains("    This is line two"));
         assert!(fluent_content.contains("    This is line three"));
-        
+
         // Verify the generated Fluent can be parsed back without errors
         let reparsed = FluentResource::from_source(&fluent_content);
-        assert!(reparsed.is_ok(), "Generated multiline Fluent should be parseable without errors");
-        
+        assert!(
+            reparsed.is_ok(),
+            "Generated multiline Fluent should be parseable without errors"
+        );
+
         let reparsed_resource = reparsed.unwrap();
         assert_eq!(reparsed_resource.messages.len(), 1);
         assert_eq!(reparsed_resource.messages[0].id, "multiline-message");

--- a/src/shared/error.rs
+++ b/src/shared/error.rs
@@ -6,33 +6,33 @@ pub enum ConversionError {
     #[allow(dead_code)]
     #[error("Failed to parse Fluent file: {0}")]
     FluentParseError(#[from] fluent_syntax::parser::ParserError),
-    
+
     #[allow(dead_code)]
     #[error("Invalid Fluent syntax: {0}")]
     InvalidFluentSyntax(String),
-    
+
     #[allow(dead_code)]
     #[error("Unsupported Fluent construct: {0}")]
     UnsupportedFluentConstruct(String),
-    
+
     // Generic input file parsing errors
     #[allow(dead_code)]
     #[error("Failed to parse input file: {0}")]
     InputFileParseError(String),
-    
+
     #[allow(dead_code)]
     #[error("Invalid input file format: {0}")]
     InputFileInvalidFormat(String),
-    
+
     #[allow(dead_code)]
     #[error("Failed to write output file: {0}")]
     OutputFileWriteError(String),
-    
+
     // General errors
     #[allow(dead_code)]
     #[error("Conversion error: {0}")]
     ConversionError(String),
-    
+
     #[allow(dead_code)]
     #[error("IO error: {0}")]
     IoError(#[from] std::io::Error),

--- a/src/shared/fluent_data.rs
+++ b/src/shared/fluent_data.rs
@@ -1,7 +1,7 @@
-use anyhow::Result;
-use std::collections::HashMap;
 use crate::shared::fluent_resource_parser::FluentResourceParser;
 use crate::shared::fluent_resource_writer::FluentResourceWriter;
+use anyhow::Result;
+use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
 pub struct FluentMessage {
@@ -33,7 +33,7 @@ pub struct FluentResource {
 
 impl FluentResource {
     /// Parse a Fluent source string into a FluentResource
-    /// 
+    ///
     /// Uses the fluent-syntax parser's built-in comment handling
     pub fn from_source(source: &str) -> Result<Self> {
         let mut parser = FluentResourceParser::new();
@@ -48,7 +48,8 @@ impl FluentResource {
 
 /// Extract plain text from a FluentPattern for use in PO conversion
 pub fn extract_pattern_text(pattern: &FluentPattern) -> String {
-    pattern.elements
+    pattern
+        .elements
         .iter()
         .map(extract_element_text)
         .collect::<Vec<_>>()
@@ -59,12 +60,12 @@ fn extract_element_text(element: &FluentElement) -> String {
     match element {
         FluentElement::Text(text) => text.clone(),
         FluentElement::Variable(var) => format!("{{${}}}", var),
-        FluentElement::Plural { selector, .. } => format!("{{ ${} }}", selector)
+        FluentElement::Plural { selector, .. } => format!("{{ ${} }}", selector),
     }
 }
 
 /// Helper function to parse text content as a Fluent pattern with proper multiline formatting
-/// 
+///
 /// This function takes raw text and formats it properly for Fluent syntax by:
 /// - Adding proper indentation to multiline text (4 spaces for continuation lines)
 /// - Parsing the formatted text through the Fluent parser to ensure valid syntax
@@ -73,16 +74,16 @@ pub fn parse_string_value_as_fluent_pattern(key: &str, text: &str) -> FluentPatt
     let formatted_text = format_string_value_as_multiline_fluent_text(text);
     let fluent_content = format!("{} = {}", key, formatted_text);
     match FluentResource::from_source(&fluent_content) {
-        Ok(resource) => {
-            resource.messages.first()
-                .and_then(|message| message.value.clone())
-                .unwrap_or_else(|| FluentPattern {
-                    elements: vec![FluentElement::Text(text.to_string())],
-                })
-        }
+        Ok(resource) => resource
+            .messages
+            .first()
+            .and_then(|message| message.value.clone())
+            .unwrap_or_else(|| FluentPattern {
+                elements: vec![FluentElement::Text(text.to_string())],
+            }),
         Err(_) => FluentPattern {
             elements: vec![FluentElement::Text(text.to_string())],
-        }
+        },
     }
 }
 
@@ -94,7 +95,7 @@ pub fn format_string_value_as_multiline_fluent_text(text: &str) -> String {
                 if i == 0 {
                     line.to_string()
                 } else {
-                    format!("    {}", line)  // Indent continuation lines with 4 spaces
+                    format!("    {}", line) // Indent continuation lines with 4 spaces
                 }
             })
             .collect::<Vec<_>>()
@@ -125,7 +126,7 @@ mod tests {
         // Simple text
         let pattern = create_text_pattern("Hello World");
         assert_eq!(extract_pattern_text(&pattern), "Hello World");
-        
+
         // Text with variable
         let pattern = FluentPattern {
             elements: vec![
@@ -135,7 +136,7 @@ mod tests {
             ],
         };
         assert_eq!(extract_pattern_text(&pattern), "Hello, {$name}!");
-        
+
         // Plural (simplified representation)
         let pattern = FluentPattern {
             elements: vec![FluentElement::Plural {
@@ -156,32 +157,32 @@ mod tests {
         } else {
             panic!("Expected text element");
         }
-        
+
         // Test multiline text
         let multiline_text = "This is line one\nThis is line two\nThis is line three";
         let pattern = parse_string_value_as_fluent_pattern("test", multiline_text);
-        
+
         // Should have 3 text elements (one per line) - this is the correct internal representation
         assert_eq!(pattern.elements.len(), 3);
-        
+
         if let FluentElement::Text(text) = &pattern.elements[0] {
             assert_eq!(text, "This is line one\n");
         } else {
             panic!("Expected text element");
         }
-        
+
         if let FluentElement::Text(text) = &pattern.elements[1] {
             assert_eq!(text, "This is line two\n");
         } else {
             panic!("Expected text element");
         }
-        
+
         if let FluentElement::Text(text) = &pattern.elements[2] {
             assert_eq!(text, "This is line three");
         } else {
             panic!("Expected text element");
         }
-        
+
         // Test that when this pattern is converted to Fluent source, it has proper indentation
         let temp_resource = FluentResource {
             messages: vec![FluentMessage {
@@ -191,13 +192,13 @@ mod tests {
                 comment: None,
             }],
         };
-        
+
         let fluent_content = temp_resource.to_source();
-        
+
         // The generated Fluent should have proper indentation
         assert!(fluent_content.contains("test-multiline ="));
         assert!(fluent_content.contains("This is line one"));
         assert!(fluent_content.contains("    This is line two"));
         assert!(fluent_content.contains("    This is line three"));
     }
-} 
+}

--- a/src/shared/fluent_resource_parser.rs
+++ b/src/shared/fluent_resource_parser.rs
@@ -1,8 +1,8 @@
+use crate::shared::fluent_data::{FluentElement, FluentMessage, FluentPattern, FluentResource};
 use anyhow::Result;
 use fluent_syntax::ast::{Entry, Expression, InlineExpression, Pattern, PatternElement};
 use fluent_syntax::parser::parse;
 use std::collections::HashMap;
-use crate::shared::fluent_data::{FluentMessage, FluentPattern, FluentElement, FluentResource};
 
 // Constants for better maintainability
 const UNSUPPORTED_PLACEHOLDER: &str = "{unsupported}";
@@ -22,9 +22,9 @@ impl FluentResourceParser {
     pub fn parse_source(&mut self, source: &str) -> Result<FluentResource> {
         let resource = parse_with_error_handling(source)?;
         self.process_entries(resource.body)?;
-        
-        Ok(FluentResource { 
-            messages: std::mem::take(&mut self.messages)
+
+        Ok(FluentResource {
+            messages: std::mem::take(&mut self.messages),
         })
     }
 
@@ -51,23 +51,25 @@ impl FluentResourceParser {
 
     fn process_message(&mut self, message: fluent_syntax::ast::Message<&str>) {
         let message_id = message.id.name.to_string();
-        
+
         // Only use comments directly associated with the message by the fluent-syntax parser
-        let comment = message.comment.map(|msg_comment| msg_comment.content.join("\n"));
-        
+        let comment = message
+            .comment
+            .map(|msg_comment| msg_comment.content.join("\n"));
+
         let fluent_message = FluentMessage {
             id: message_id,
             value: message.value.map(|pattern| convert_pattern(&pattern)),
             attributes: self.convert_attributes(message.attributes),
             comment,
         };
-        
+
         self.messages.push(fluent_message);
     }
 
     fn convert_attributes(
-        &self, 
-        attributes: Vec<fluent_syntax::ast::Attribute<&str>>
+        &self,
+        attributes: Vec<fluent_syntax::ast::Attribute<&str>>,
     ) -> HashMap<String, FluentPattern> {
         attributes
             .into_iter()
@@ -90,7 +92,8 @@ fn parse_with_error_handling(source: &str) -> Result<fluent_syntax::ast::Resourc
 }
 
 fn convert_pattern(pattern: &Pattern<&str>) -> FluentPattern {
-    let elements = pattern.elements
+    let elements = pattern
+        .elements
         .iter()
         .map(convert_pattern_element)
         .collect();
@@ -100,12 +103,8 @@ fn convert_pattern(pattern: &Pattern<&str>) -> FluentPattern {
 
 fn convert_pattern_element(element: &PatternElement<&str>) -> FluentElement {
     match element {
-        PatternElement::TextElement { value } => {
-            FluentElement::Text(value.to_string())
-        }
-        PatternElement::Placeable { expression } => {
-            convert_expression(expression)
-        }
+        PatternElement::TextElement { value } => FluentElement::Text(value.to_string()),
+        PatternElement::Placeable { expression } => convert_expression(expression),
     }
 }
 
@@ -114,12 +113,8 @@ fn convert_expression(expression: &Expression<&str>) -> FluentElement {
         Expression::Inline(InlineExpression::VariableReference { id }) => {
             FluentElement::Variable(id.name.to_string())
         }
-        Expression::Select { selector, variants } => {
-            convert_select_expression(selector, variants)
-        }
-        _ => {
-            FluentElement::Text(UNSUPPORTED_PLACEHOLDER.to_string())
-        }
+        Expression::Select { selector, variants } => convert_select_expression(selector, variants),
+        _ => FluentElement::Text(UNSUPPORTED_PLACEHOLDER.to_string()),
     }
 }
 
@@ -161,7 +156,7 @@ fn variant_key_to_string(key: &fluent_syntax::ast::VariantKey<&str>) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::shared::fluent_data::{extract_pattern_text};
+    use crate::shared::fluent_data::extract_pattern_text;
 
     // Helper function to assert a pattern contains expected text
     fn assert_pattern_text(pattern: &FluentPattern, expected: &str) {
@@ -176,11 +171,11 @@ mod tests {
     fn test_parse_simple_message() {
         let ftl = "hello = Hello World";
         let resource = FluentResource::from_source(ftl).unwrap();
-        
+
         assert_eq!(resource.messages.len(), 1);
         assert_eq!(resource.messages[0].id, "hello");
         assert!(resource.messages[0].value.is_some());
-        
+
         let pattern = resource.messages[0].value.as_ref().unwrap();
         assert_eq!(pattern.elements.len(), 1);
         assert_pattern_text(pattern, "Hello World");
@@ -207,21 +202,21 @@ mod tests {
    *[other] {$count} items
 }"#;
         let resource = FluentResource::from_source(ftl).unwrap();
-        
+
         assert_eq!(resource.messages.len(), 1);
         let pattern = resource.messages[0].value.as_ref().unwrap();
         assert_eq!(pattern.elements.len(), 1);
-        
+
         if let FluentElement::Plural { selector, variants } = &pattern.elements[0] {
             assert_eq!(selector, "count");
             assert_eq!(variants.len(), 2);
             assert!(variants.contains_key("one"));
             assert!(variants.contains_key("other"));
-            
+
             // Test that the variants contain the expected content
             let one_pattern = variants.get("one").unwrap();
             assert_eq!(extract_pattern_text(one_pattern), "{$count} item");
-            
+
             let other_pattern = variants.get("other").unwrap();
             assert_eq!(extract_pattern_text(other_pattern), "{$count} items");
         } else {
@@ -234,24 +229,24 @@ mod tests {
         let ftl = r#"login-button = Sign In
     .aria-label = Sign in to your account
     .title = Click to sign in"#;
-        
+
         let resource = FluentResource::from_source(ftl).unwrap();
-        
+
         assert_eq!(resource.messages.len(), 1);
         let message = &resource.messages[0];
         assert_eq!(message.id, "login-button");
-        
+
         // Check main value
         assert!(message.value.is_some());
         let value = message.value.as_ref().unwrap();
         assert_eq!(value.elements.len(), 1);
         assert_pattern_text(value, "Sign In");
-        
+
         // Check attributes
         assert_eq!(message.attributes.len(), 2);
         assert!(message.attributes.contains_key("aria-label"));
         assert!(message.attributes.contains_key("title"));
-        
+
         let aria_label = message.attributes.get("aria-label").unwrap();
         assert_pattern_text(aria_label, "Sign in to your account");
     }
@@ -266,24 +261,28 @@ hello = Hello World
 # Another comment
 # for a different message
 goodbye = Goodbye!"#;
-        
+
         let resource = FluentResource::from_source(ftl).unwrap();
-        
+
         assert_eq!(resource.messages.len(), 2);
-        
+
         // Check first message comment - assert exact content to ensure no extra characters or indentation
         assert!(resource.messages[0].comment.is_some());
         let hello_comment = resource.messages[0].comment.as_ref().unwrap();
         let expected_hello_comment = "This is a greeting message\nIt supports internationalization\nand has multiple lines of comments";
-        assert_eq!(hello_comment, expected_hello_comment,
-                   "Comment should contain exact content without # characters or extra indentation");
-        
+        assert_eq!(
+            hello_comment, expected_hello_comment,
+            "Comment should contain exact content without # characters or extra indentation"
+        );
+
         // Check second message comment - assert exact content
         assert!(resource.messages[1].comment.is_some());
         let goodbye_comment = resource.messages[1].comment.as_ref().unwrap();
         let expected_goodbye_comment = "Another comment\nfor a different message";
-        assert_eq!(goodbye_comment, expected_goodbye_comment,
-                   "Comment should contain exact content without # characters or extra indentation");
+        assert_eq!(
+            goodbye_comment, expected_goodbye_comment,
+            "Comment should contain exact content without # characters or extra indentation"
+        );
     }
 
     #[test]
@@ -293,17 +292,17 @@ goodbye = Goodbye!"#;
     [1] One file
    *[other] {$count} files
 }"#;
-        
+
         let resource = FluentResource::from_source(ftl).unwrap();
-        
+
         assert_eq!(resource.messages.len(), 1);
         let pattern = resource.messages[0].value.as_ref().unwrap();
-        
+
         if let FluentElement::Plural { variants, .. } = &pattern.elements[0] {
             assert!(variants.contains_key("0"));
             assert!(variants.contains_key("1"));
             assert!(variants.contains_key("other"));
-            
+
             // Check that numeric keys are preserved
             let zero_pattern = variants.get("0").unwrap();
             assert_pattern_text(zero_pattern, "No files");
@@ -331,7 +330,7 @@ goodbye = Goodbye!"#;
         // Test that numeric values are preserved as-is for round-trip conversion
         let numeric_key = fluent_syntax::ast::VariantKey::NumberLiteral { value: "1" };
         assert_eq!(variant_key_to_string(&numeric_key), "1");
-        
+
         let identifier_key = fluent_syntax::ast::VariantKey::Identifier { name: "few" };
         assert_eq!(variant_key_to_string(&identifier_key), "few");
     }
@@ -423,4 +422,4 @@ hello = Hello"#;
         assert_eq!(pattern.elements.len(), 1);
         assert_pattern_text(pattern, "Hello World");
     }
-} 
+}

--- a/src/shared/fluent_resource_writer.rs
+++ b/src/shared/fluent_resource_writer.rs
@@ -1,6 +1,6 @@
+use crate::shared::fluent_data::{FluentElement, FluentMessage, FluentPattern, FluentResource};
 use fluent_syntax::serializer;
 use std::collections::HashMap;
-use crate::shared::fluent_data::{FluentMessage, FluentPattern, FluentElement, FluentResource};
 
 // Type aliases for better readability of AST types
 type AstMessage = fluent_syntax::ast::Message<String>;
@@ -9,8 +9,7 @@ type AstPatternElement = fluent_syntax::ast::PatternElement<String>;
 type AstVariant = fluent_syntax::ast::Variant<String>;
 type AstIdentifier = fluent_syntax::ast::Identifier<String>;
 
-pub struct FluentResourceWriter {
-}
+pub struct FluentResourceWriter {}
 
 impl FluentResourceWriter {
     pub fn new() -> Self {
@@ -23,7 +22,7 @@ impl FluentResourceWriter {
         if resource.messages.is_empty() {
             return output;
         }
-        
+
         // At this point we could serialize the entire structure with the library, but that will generate a
         // Fluent file without empty lines between strings
         for (i, message) in resource.messages.iter().enumerate() {
@@ -31,7 +30,7 @@ impl FluentResourceWriter {
             if i > 0 {
                 output.push('\n');
             }
-            
+
             // Generate each message individually using the built-in serializer
             let temp_resource = FluentResource {
                 messages: vec![message.clone()],
@@ -41,13 +40,17 @@ impl FluentResourceWriter {
             let serialized = serializer::serialize(&ast_resource);
             output.push_str(&serialized);
         }
-        
+
         output
     }
 
     /// Convert our custom FluentResource back to fluent_syntax AST for serialization
-    fn to_fluent_syntax_ast(&self, resource: &FluentResource) -> fluent_syntax::ast::Resource<String> {
-        let entries: Vec<fluent_syntax::ast::Entry<String>> = resource.messages
+    fn to_fluent_syntax_ast(
+        &self,
+        resource: &FluentResource,
+    ) -> fluent_syntax::ast::Resource<String> {
+        let entries: Vec<fluent_syntax::ast::Entry<String>> = resource
+            .messages
             .iter()
             .map(|message| fluent_syntax::ast::Entry::Message(self.convert_message_to_ast(message)))
             .collect();
@@ -58,9 +61,13 @@ impl FluentResourceWriter {
     /// Convert a FluentMessage to fluent_syntax AST Message
     fn convert_message_to_ast(&self, message: &FluentMessage) -> AstMessage {
         let id = Self::create_identifier(&message.id);
-        let value = message.value.as_ref().map(|pattern| self.convert_pattern_to_ast(pattern));
-        
-        let attributes: Vec<fluent_syntax::ast::Attribute<String>> = message.attributes
+        let value = message
+            .value
+            .as_ref()
+            .map(|pattern| self.convert_pattern_to_ast(pattern));
+
+        let attributes: Vec<fluent_syntax::ast::Attribute<String>> = message
+            .attributes
             .iter()
             .map(|(attr_name, attr_pattern)| fluent_syntax::ast::Attribute {
                 id: Self::create_identifier(attr_name),
@@ -68,11 +75,12 @@ impl FluentResourceWriter {
             })
             .collect();
 
-        let comment = message.comment.as_ref().map(|comment_text| {
-            fluent_syntax::ast::Comment {
+        let comment = message
+            .comment
+            .as_ref()
+            .map(|comment_text| fluent_syntax::ast::Comment {
                 content: comment_text.lines().map(|line| line.to_string()).collect(),
-            }
-        });
+            });
 
         fluent_syntax::ast::Message {
             id,
@@ -84,7 +92,8 @@ impl FluentResourceWriter {
 
     /// Convert a FluentPattern to fluent_syntax AST Pattern
     fn convert_pattern_to_ast(&self, pattern: &FluentPattern) -> AstPattern {
-        let elements: Vec<AstPatternElement> = pattern.elements
+        let elements: Vec<AstPatternElement> = pattern
+            .elements
             .iter()
             .map(|element| self.convert_element_to_ast(element))
             .collect();
@@ -95,14 +104,10 @@ impl FluentResourceWriter {
     /// Convert a FluentElement to fluent_syntax AST PatternElement
     fn convert_element_to_ast(&self, element: &FluentElement) -> AstPatternElement {
         match element {
-            FluentElement::Text(text) => {
-                fluent_syntax::ast::PatternElement::TextElement {
-                    value: text.clone(),
-                }
-            }
-            FluentElement::Variable(var_name) => {
-                self.create_variable_placeable(var_name)
-            }
+            FluentElement::Text(text) => fluent_syntax::ast::PatternElement::TextElement {
+                value: text.clone(),
+            },
+            FluentElement::Variable(var_name) => self.create_variable_placeable(var_name),
             FluentElement::Plural { selector, variants } => {
                 self.create_plural_placeable(selector, variants)
             }
@@ -111,13 +116,17 @@ impl FluentResourceWriter {
 
     fn create_variable_placeable(&self, var_name: &str) -> AstPatternElement {
         fluent_syntax::ast::PatternElement::Placeable {
-            expression: fluent_syntax::ast::Expression::Inline(
-                Self::create_variable_reference(var_name)
-            ),
+            expression: fluent_syntax::ast::Expression::Inline(Self::create_variable_reference(
+                var_name,
+            )),
         }
     }
 
-    fn create_plural_placeable(&self, selector: &str, variants: &HashMap<String, FluentPattern>) -> AstPatternElement {
+    fn create_plural_placeable(
+        &self,
+        selector: &str,
+        variants: &HashMap<String, FluentPattern>,
+    ) -> AstPatternElement {
         let selector_expr = Self::create_variable_reference(selector);
         let ast_variants = self.convert_variants_to_ast(variants);
 
@@ -129,15 +138,16 @@ impl FluentResourceWriter {
         }
     }
 
-    fn convert_variants_to_ast(&self, variants: &HashMap<String, FluentPattern>) -> Vec<AstVariant> {
+    fn convert_variants_to_ast(
+        &self,
+        variants: &HashMap<String, FluentPattern>,
+    ) -> Vec<AstVariant> {
         variants
             .iter()
-            .map(|(key, pattern)| {
-                fluent_syntax::ast::Variant {
-                    key: Self::create_variant_key(key),
-                    value: self.convert_pattern_to_ast(pattern),
-                    default: key == "other",
-                }
+            .map(|(key, pattern)| fluent_syntax::ast::Variant {
+                key: Self::create_variant_key(key),
+                value: self.convert_pattern_to_ast(pattern),
+                default: key == "other",
             })
             .collect()
     }
@@ -171,7 +181,6 @@ impl FluentResourceWriter {
 #[cfg(test)]
 mod tests {
     use super::*;
-
 
     // Helper function to create a simple FluentPattern with text
     fn create_text_pattern(text: &str) -> FluentPattern {
@@ -217,8 +226,8 @@ multiline = This is line one
         let expected_content = [
             "hello = Hello World",
             "greeting = Hello, { $name }!", // Normalized variable formatting
-            "items =", // Multiline formatting for plurals
-            "{ $count ->", // Selector on separate line
+            "items =",                      // Multiline formatting for plurals
+            "{ $count ->",                  // Selector on separate line
             "[0] No items",
             "*[other] { $count } items", // Normalized variable formatting
             "save-button = Save",
@@ -238,7 +247,11 @@ multiline = This is line one
         ];
 
         for comment in &expected_comments {
-            assert!(generated_ftl.contains(comment), "Missing comment: {}", comment);
+            assert!(
+                generated_ftl.contains(comment),
+                "Missing comment: {}",
+                comment
+            );
         }
     }
 
@@ -266,7 +279,7 @@ multiline = This is line one
                 },
             ],
         };
-        
+
         let source = resource.to_source();
         assert!(source.contains("hello = Hello World"));
         // Built-in serializer normalizes variable formatting to include spaces
@@ -283,14 +296,14 @@ multiline = This is line one
         assert_eq!(resource.messages.len(), 1);
 
         let generated = resource.to_source();
-        
+
         // The built-in serializer formats multiline messages with proper indentation
         // Verify that the content is preserved correctly
         assert!(generated.contains("multiline ="));
         assert!(generated.contains("This is line one"));
         assert!(generated.contains("This is line two"));
         assert!(generated.contains("And this is line three"));
-        
+
         // Parse it back to ensure round-trip works semantically
         let reparsed = FluentResource::from_source(&generated).unwrap();
         assert_eq!(reparsed.messages.len(), 1);
@@ -314,15 +327,15 @@ items = {$count ->
 }"#;
 
         let resource = FluentResource::from_source(original_ftl).unwrap();
-        
+
         // Our to_source now uses the built-in serializer
         let output = resource.to_source();
-        
+
         // Should parse back to equivalent resource
         let reparsed = FluentResource::from_source(&output).unwrap();
-        
+
         assert_eq!(resource.messages.len(), reparsed.messages.len());
-        
+
         // Verify that content is preserved
         for (original_msg, reparsed_msg) in resource.messages.iter().zip(reparsed.messages.iter()) {
             assert_eq!(original_msg.id, reparsed_msg.id);
@@ -330,4 +343,4 @@ items = {$count ->
             // Note: The built-in serializer may normalize formatting, but semantic content should be the same
         }
     }
-} 
+}

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -1,4 +1,4 @@
+pub mod error;
 pub mod fluent_data;
 pub mod fluent_resource_parser;
 pub mod fluent_resource_writer;
-pub mod error;


### PR DESCRIPTION
This PR introduces Rust code formatting enforcement using `rustfmt` and adds the necessary infrastructure to check formatting in CI.

## Changes

- Added Makefile tasks for Rust linting and formatting (`lint-rust`, `fmt-rust`, `fmt-check-rust`)
- Added Buildkite CI job to check Rust formatting compliance
- Applied `cargo fmt --all` to format the entire codebase

## Notes

- The Clippy linting step is currently commented out in CI due to existing warnings that will be addressed in a follow-up PR
- All Rust code now conforms to standard `rustfmt` formatting rules