### PR TITLE
Address Clippy Issues

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -37,6 +37,9 @@ steps:
 
       echo "--- :rust: Ensuring Code Conforms to rustfmt"
       make fmt-check-rust
+    notify:
+      - github_commit_status:
+          context: "Rust Lint"
   - label: ":ruby: Rubocop + RSpec"
     # for now, running in the default queue to avoid the need of a Gemfile the root directory
     command: cd ruby && bundle install && bundle exec rubocop && bundle exec rspec

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -32,8 +32,8 @@ steps:
   #################
   - label: ":rust: Lint"
     command: |
-      # echo "--- :rust: Running Clippy"
-      # make lint-rust
+      echo "--- :rust: Running Clippy"
+      make lint-rust
 
       echo "--- :rust: Ensuring Code Conforms to rustfmt"
       make fmt-check-rust

--- a/src/po/cldr_plural_rules.rs
+++ b/src/po/cldr_plural_rules.rs
@@ -182,6 +182,7 @@ pub fn is_other_category(key: &str) -> bool {
 /// - Russian: ["one", "few", "other"]
 /// - Arabic: ["zero", "one", "two", "few", "many", "other"]
 /// - Chinese: ["other"]
+///
 /// Get the plural forms string for a locale (for PO metadata)
 pub fn get_plural_forms_for_locale(locale: &str) -> &'static str {
     // Try exact match first

--- a/src/po/po_format.rs
+++ b/src/po/po_format.rs
@@ -1,21 +1,25 @@
-use polib::catalog::Catalog;
-use polib::message::{Message as PoMessage, MessageView};
-use polib::metadata::CatalogMetadata;
-use polib::po_file;
-
-use crate::po::cldr_plural_rules::{
-    get_plural_forms_for_locale, is_other_category, is_singular_category,
-    map_cldr_categories_to_po_indices_for_locale, map_po_indices_to_cldr_categories_for_locale,
-    CLDR_OTHER_CATEGORY, DEFAULT_PLURAL_FORMS,
-};
-use crate::shared::error::ConversionError;
-use crate::shared::fluent_data::{
-    extract_pattern_text, parse_string_value_as_fluent_pattern, FluentElement, FluentMessage,
-    FluentPattern, FluentResource,
+use crate::{
+    po::cldr_plural_rules::{
+        CLDR_OTHER_CATEGORY, DEFAULT_PLURAL_FORMS, get_plural_forms_for_locale, is_other_category,
+        is_singular_category, map_cldr_categories_to_po_indices_for_locale,
+        map_po_indices_to_cldr_categories_for_locale,
+    },
+    shared::{
+        error::ConversionError,
+        fluent_data::{
+            FluentElement, FluentMessage, FluentPattern, FluentResource, extract_pattern_text,
+            parse_string_value_as_fluent_pattern,
+        },
+    },
 };
 use anyhow::Result;
-use std::collections::HashMap;
-use std::path::Path;
+use polib::{
+    catalog::Catalog,
+    message::{Message as PoMessage, MessageView},
+    metadata::CatalogMetadata,
+    po_file,
+};
+use std::{collections::HashMap, path::Path};
 
 // =============================================================================
 // Constants

--- a/src/po/po_format.rs
+++ b/src/po/po_format.rs
@@ -194,7 +194,7 @@ impl<'a> PoContentProcessor<'a> {
     fn finalize_header(&mut self) {
         self.header_section = false;
         self.add_missing_metadata_fields();
-        self.result.extend(self.header_lines.drain(..));
+        self.result.append(&mut self.header_lines);
     }
 
     fn add_missing_metadata_fields(&mut self) {
@@ -351,7 +351,7 @@ fn convert_message_attributes(
 
         let source_attr_text = source_message
             .and_then(|sm| sm.attributes.get(attr_name))
-            .map(|sp| extract_pattern_text(sp));
+            .map(extract_pattern_text);
 
         let msgid = source_attr_text.unwrap_or_else(|| target_attr_text.clone());
 
@@ -379,7 +379,7 @@ fn convert_singular_po_message_to_fluent_message(
     }
 
     // Simply try to parse the unescaped content as a Fluent message value
-    let unescaped_msgstr = unescape_fluent_value(&msgstr);
+    let unescaped_msgstr = unescape_fluent_value(msgstr);
     let pattern = parse_string_value_as_fluent_pattern(key, &unescaped_msgstr);
 
     // Extract comments (excluding FLUENT_SELECTOR comments which are handled separately)
@@ -569,7 +569,7 @@ fn generate_fluent_key_from_message(message: &dyn MessageView) -> String {
 fn get_source_text_or_target(source_message: Option<&FluentMessage>, target_text: &str) -> String {
     source_message
         .and_then(|sm| sm.value.as_ref())
-        .map(|sp| extract_pattern_text(sp))
+        .map(extract_pattern_text)
         .unwrap_or_else(|| target_text.to_string())
 }
 

--- a/src/po/po_format.rs
+++ b/src/po/po_format.rs
@@ -4,14 +4,14 @@ use polib::metadata::CatalogMetadata;
 use polib::po_file;
 
 use crate::po::cldr_plural_rules::{
-    CLDR_OTHER_CATEGORY, DEFAULT_PLURAL_FORMS, get_plural_forms_for_locale, is_other_category,
-    is_singular_category, map_cldr_categories_to_po_indices_for_locale,
-    map_po_indices_to_cldr_categories_for_locale,
+    get_plural_forms_for_locale, is_other_category, is_singular_category,
+    map_cldr_categories_to_po_indices_for_locale, map_po_indices_to_cldr_categories_for_locale,
+    CLDR_OTHER_CATEGORY, DEFAULT_PLURAL_FORMS,
 };
 use crate::shared::error::ConversionError;
 use crate::shared::fluent_data::{
-    FluentElement, FluentMessage, FluentPattern, FluentResource, extract_pattern_text,
-    parse_string_value_as_fluent_pattern,
+    extract_pattern_text, parse_string_value_as_fluent_pattern, FluentElement, FluentMessage,
+    FluentPattern, FluentResource,
 };
 use anyhow::Result;
 use std::collections::HashMap;
@@ -758,8 +758,10 @@ mod tests {
     #[test]
     fn test_po_catalog_to_fluent() {
         // Test both simple and plural messages
-        let mut metadata = CatalogMetadata::default();
-        metadata.language = "en".to_string();
+        let metadata = CatalogMetadata {
+            language: "en".to_string(),
+            ..Default::default()
+        };
         let mut catalog = Catalog::new(metadata);
 
         // Simple message
@@ -916,9 +918,11 @@ mod tests {
         let po_path = temp_dir.path().join("test.po");
 
         // Create a catalog
-        let mut metadata = CatalogMetadata::default();
-        metadata.language = "en".to_string();
-        metadata.content_type = DEFAULT_CHARSET.to_string();
+        let metadata = CatalogMetadata {
+            language: "en".to_string(),
+            content_type: DEFAULT_CHARSET.to_string(),
+            ..Default::default()
+        };
 
         let mut catalog = Catalog::new(metadata);
 
@@ -953,9 +957,11 @@ mod tests {
     #[test]
     fn test_po_to_fluent_empty_msgstr_edge_cases() {
         // Test that empty msgstr values are omitted and don't create extra empty lines
-        let mut metadata = CatalogMetadata::default();
-        metadata.language = "en".to_string();
-        metadata.content_type = "text/plain; charset=UTF-8".to_string();
+        let metadata = CatalogMetadata {
+            language: "en".to_string(),
+            content_type: "text/plain; charset=UTF-8".to_string(),
+            ..Default::default()
+        };
 
         let mut catalog = Catalog::new(metadata);
 
@@ -1018,9 +1024,11 @@ mod tests {
     #[test]
     fn test_multiline_po_to_fluent_formatting() {
         // Test that multiline PO messages are correctly formatted with proper indentation
-        let mut metadata = CatalogMetadata::default();
-        metadata.language = "en".to_string();
-        metadata.content_type = "text/plain; charset=UTF-8".to_string();
+        let metadata = CatalogMetadata {
+            language: "en".to_string(),
+            content_type: "text/plain".to_string(),
+            ..Default::default()
+        };
 
         let mut catalog = Catalog::new(metadata);
 

--- a/src/shared/error.rs
+++ b/src/shared/error.rs
@@ -30,8 +30,8 @@ pub enum ConversionError {
 
     // General errors
     #[allow(dead_code)]
-    #[error("Conversion error: {0}")]
-    ConversionError(String),
+    #[error("Other conversion error: {0}")]
+    Other(String),
 
     #[allow(dead_code)]
     #[error("IO error: {0}")]


### PR DESCRIPTION
This PR addresses various clippy warnings and enables clippy in CI to maintain code quality.

## Changes

- **Enable clippy in CI** - Added clippy checks to the Buildkite pipeline
- **Fix clippy warnings** across the codebase:
  - Use `..Default::default()` syntax instead of mutable variables
  - Address remaining clippy issues in error handling and PO format modules
