### PR TITLE
Refactor `FluentResourceParser` for Better Code Organization

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -65,17 +65,8 @@ enum FormatCommands {
     },
 }
 
-fn main() {
-    let cli = Cli::parse();
-
-    if let Err(e) = run(cli) {
-        eprintln!("Error: {}", e);
-        std::process::exit(1);
-    }
-}
-
-fn run(cli: Cli) -> Result<()> {
-    match cli.command {
+fn main() -> Result<()> {
+    match Cli::parse().command {
         Commands::Android { android_command } => match android_command {
             FormatCommands::FromFluent { input, output, .. } => {
                 fluent_to_android(&input, &output)?;

--- a/src/shared/fluent_data.rs
+++ b/src/shared/fluent_data.rs
@@ -42,9 +42,7 @@ impl From<fluent_syntax::ast::Message<&str>> for FluentMessage {
 
         Self {
             id: message_id,
-            value: message
-                .value
-                .map(|pattern| FluentResourceParser::convert_pattern(&pattern)),
+            value: message.value.as_ref().map(Into::into),
             attributes: FluentResourceParser::convert_attributes(message.attributes),
             comment,
         }

--- a/src/shared/fluent_data.rs
+++ b/src/shared/fluent_data.rs
@@ -36,8 +36,7 @@ impl FluentResource {
     ///
     /// Uses the fluent-syntax parser's built-in comment handling
     pub fn from_source(source: &str) -> Result<Self> {
-        let mut parser = FluentResourceParser::new();
-        parser.parse_source(source)
+        FluentResourceParser::parse_source(source)
     }
 
     pub fn to_source(&self) -> String {

--- a/src/shared/fluent_data.rs
+++ b/src/shared/fluent_data.rs
@@ -1,6 +1,8 @@
-use crate::shared::fluent_resource_parser::FluentResourceParser;
-use crate::shared::fluent_resource_writer::FluentResourceWriter;
-use anyhow::Result;
+use crate::shared::{
+    fluent_resource_parser::FluentResourceParser, fluent_resource_writer::FluentResourceWriter,
+};
+use anyhow::{anyhow, Result};
+use fluent_syntax::ast::Entry;
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
@@ -9,6 +11,24 @@ pub struct FluentMessage {
     pub value: Option<FluentPattern>,
     pub attributes: HashMap<String, FluentPattern>,
     pub comment: Option<String>,
+}
+
+impl TryFrom<Entry<&str>> for FluentMessage {
+    type Error = anyhow::Error;
+
+    fn try_from(entry: Entry<&str>) -> Result<Self> {
+        match entry {
+            Entry::Message(message) => Ok(FluentResourceParser::process_message(message)),
+            Entry::Comment(_) => Err(anyhow!(
+                "Standalone comments are ignored - only use parser's built-in comment association"
+            )),
+            Entry::GroupComment(_) | Entry::ResourceComment(_) => {
+                Err(anyhow!("Ignore group and resource comments for now"))
+            }
+            Entry::Term(_) => Err(anyhow!("Handle terms if needed in the future")),
+            Entry::Junk { .. } => Err(anyhow!("Ignore junk entries")),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/shared/fluent_data.rs
+++ b/src/shared/fluent_data.rs
@@ -1,7 +1,7 @@
 use crate::shared::{
     fluent_resource_parser::FluentResourceParser, fluent_resource_writer::FluentResourceWriter,
 };
-use anyhow::{anyhow, Result};
+use anyhow::{Result, anyhow};
 use fluent_syntax::ast::{Entry, Expression, InlineExpression, Pattern, PatternElement};
 use std::collections::HashMap;
 

--- a/src/shared/fluent_data.rs
+++ b/src/shared/fluent_data.rs
@@ -18,7 +18,7 @@ impl TryFrom<Entry<&str>> for FluentMessage {
 
     fn try_from(entry: Entry<&str>) -> Result<Self> {
         match entry {
-            Entry::Message(message) => Ok(FluentResourceParser::process_message(message)),
+            Entry::Message(message) => Ok(message.into()),
             Entry::Comment(_) => Err(anyhow!(
                 "Standalone comments are ignored - only use parser's built-in comment association"
             )),

--- a/src/shared/fluent_data.rs
+++ b/src/shared/fluent_data.rs
@@ -31,6 +31,26 @@ impl TryFrom<Entry<&str>> for FluentMessage {
     }
 }
 
+impl From<fluent_syntax::ast::Message<&str>> for FluentMessage {
+    fn from(message: fluent_syntax::ast::Message<&str>) -> Self {
+        let message_id = message.id.name.to_string();
+
+        // Only use comments directly associated with the message by the fluent-syntax parser
+        let comment = message
+            .comment
+            .map(|msg_comment| msg_comment.content.join("\n"));
+
+        Self {
+            id: message_id,
+            value: message
+                .value
+                .map(|pattern| FluentResourceParser::convert_pattern(&pattern)),
+            attributes: FluentResourceParser::convert_attributes(message.attributes),
+            comment,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct FluentPattern {
     pub elements: Vec<FluentElement>,

--- a/src/shared/fluent_data.rs
+++ b/src/shared/fluent_data.rs
@@ -2,8 +2,10 @@ use crate::shared::{
     fluent_resource_parser::FluentResourceParser, fluent_resource_writer::FluentResourceWriter,
 };
 use anyhow::{anyhow, Result};
-use fluent_syntax::ast::{Entry, Pattern};
+use fluent_syntax::ast::{Entry, Expression, InlineExpression, Pattern};
 use std::collections::HashMap;
+
+use super::fluent_resource_parser::UNSUPPORTED_PLACEHOLDER;
 
 #[derive(Debug, Clone)]
 pub struct FluentMessage {
@@ -74,6 +76,20 @@ pub enum FluentElement {
         selector: String,
         variants: HashMap<String, FluentPattern>,
     },
+}
+
+impl From<&Expression<&str>> for FluentElement {
+    fn from(expression: &Expression<&str>) -> Self {
+        match expression {
+            Expression::Inline(InlineExpression::VariableReference { id }) => {
+                FluentElement::Variable(id.name.to_string())
+            }
+            Expression::Select { selector, variants } => {
+                FluentResourceParser::convert_select_expression(selector, variants)
+            }
+            _ => FluentElement::Text(UNSUPPORTED_PLACEHOLDER.to_string()),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/shared/fluent_data.rs
+++ b/src/shared/fluent_data.rs
@@ -2,7 +2,7 @@ use crate::shared::{
     fluent_resource_parser::FluentResourceParser, fluent_resource_writer::FluentResourceWriter,
 };
 use anyhow::{anyhow, Result};
-use fluent_syntax::ast::Entry;
+use fluent_syntax::ast::{Entry, Pattern};
 use std::collections::HashMap;
 
 #[derive(Debug, Clone)]
@@ -54,6 +54,18 @@ impl From<fluent_syntax::ast::Message<&str>> for FluentMessage {
 #[derive(Debug, Clone)]
 pub struct FluentPattern {
     pub elements: Vec<FluentElement>,
+}
+
+impl From<&Pattern<&str>> for FluentPattern {
+    fn from(pattern: &Pattern<&str>) -> Self {
+        Self {
+            elements: pattern
+                .elements
+                .iter()
+                .map(FluentResourceParser::convert_pattern_element)
+                .collect(),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/shared/fluent_data.rs
+++ b/src/shared/fluent_data.rs
@@ -45,7 +45,11 @@ impl From<fluent_syntax::ast::Message<&str>> for FluentMessage {
         Self {
             id: message_id,
             value: message.value.as_ref().map(Into::into),
-            attributes: FluentResourceParser::convert_attributes(message.attributes),
+            attributes: message
+                .attributes
+                .iter()
+                .map(|attr| (attr.id.name.to_string(), (&attr.value).into()))
+                .collect(),
             comment,
         }
     }

--- a/src/shared/fluent_data.rs
+++ b/src/shared/fluent_data.rs
@@ -2,7 +2,7 @@ use crate::shared::{
     fluent_resource_parser::FluentResourceParser, fluent_resource_writer::FluentResourceWriter,
 };
 use anyhow::{anyhow, Result};
-use fluent_syntax::ast::{Entry, Expression, InlineExpression, Pattern};
+use fluent_syntax::ast::{Entry, Expression, InlineExpression, Pattern, PatternElement};
 use std::collections::HashMap;
 
 use super::fluent_resource_parser::UNSUPPORTED_PLACEHOLDER;
@@ -59,11 +59,7 @@ pub struct FluentPattern {
 impl From<&Pattern<&str>> for FluentPattern {
     fn from(pattern: &Pattern<&str>) -> Self {
         Self {
-            elements: pattern
-                .elements
-                .iter()
-                .map(FluentResourceParser::convert_pattern_element)
-                .collect(),
+            elements: pattern.elements.iter().map(Into::into).collect(),
         }
     }
 }
@@ -88,6 +84,15 @@ impl From<&Expression<&str>> for FluentElement {
                 FluentResourceParser::convert_select_expression(selector, variants)
             }
             _ => FluentElement::Text(UNSUPPORTED_PLACEHOLDER.to_string()),
+        }
+    }
+}
+
+impl From<&PatternElement<&str>> for FluentElement {
+    fn from(element: &PatternElement<&str>) -> Self {
+        match element {
+            PatternElement::TextElement { value } => FluentElement::Text(value.to_string()),
+            PatternElement::Placeable { expression } => expression.into(),
         }
     }
 }

--- a/src/shared/fluent_resource_parser.rs
+++ b/src/shared/fluent_resource_parser.rs
@@ -81,13 +81,7 @@ impl FluentResourceParser {
 fn parse_with_error_handling(source: &str) -> Result<fluent_syntax::ast::Resource<&str>> {
     match parse(source) {
         Ok(resource) => Ok(resource),
-        Err((resource, errors)) => {
-            if errors.is_empty() {
-                Ok(resource)
-            } else {
-                Err(anyhow::anyhow!("Fluent parse errors: {:#?}", errors))
-            }
-        }
+        Err((_resource, errors)) => Err(anyhow::anyhow!("Fluent parse errors: {:#?}", errors)),
     }
 }
 

--- a/src/shared/fluent_resource_parser.rs
+++ b/src/shared/fluent_resource_parser.rs
@@ -30,8 +30,8 @@ impl FluentResourceParser {
         attributes: Vec<fluent_syntax::ast::Attribute<&str>>,
     ) -> HashMap<String, FluentPattern> {
         attributes
-            .into_iter()
-            .map(|attr| (attr.id.name.to_string(), Self::convert_pattern(&attr.value)))
+            .iter()
+            .map(|attr| (attr.id.name.to_string(), (&attr.value).into()))
             .collect()
     }
 
@@ -52,7 +52,7 @@ impl FluentResourceParser {
         }
     }
 
-    fn convert_pattern_element(element: &PatternElement<&str>) -> FluentElement {
+    pub fn convert_pattern_element(element: &PatternElement<&str>) -> FluentElement {
         match element {
             PatternElement::TextElement { value } => FluentElement::Text(value.to_string()),
             PatternElement::Placeable { expression } => Self::convert_expression(expression),

--- a/src/shared/fluent_resource_parser.rs
+++ b/src/shared/fluent_resource_parser.rs
@@ -7,48 +7,45 @@ use std::collections::HashMap;
 const UNSUPPORTED_PLACEHOLDER: &str = "{unsupported}";
 
 /// Internal parser state for processing Fluent AST entries
-pub struct FluentResourceParser {
-    messages: Vec<FluentMessage>,
-}
+pub struct FluentResourceParser;
 
 impl FluentResourceParser {
-    pub fn new() -> Self {
-        Self {
-            messages: Vec::new(),
-        }
-    }
-
-    pub fn parse_source(&mut self, source: &str) -> Result<FluentResource> {
+    pub fn parse_source(source: &str) -> Result<FluentResource> {
         let resource = parse_with_error_handling(source)?;
-        self.process_entries(resource.body)?;
 
         Ok(FluentResource {
-            messages: std::mem::take(&mut self.messages),
+            messages: Self::process_entries(resource.body),
         })
     }
 
-    fn process_entries(&mut self, entries: Vec<Entry<&str>>) -> Result<()> {
-        for entry in entries {
-            match entry {
-                Entry::Message(message) => self.process_message(message),
-                Entry::Comment(_) => {
-                    // Standalone comments are ignored - only use parser's built-in comment association
+    fn process_entries(entries: Vec<Entry<&str>>) -> Vec<FluentMessage> {
+        entries
+            .into_iter()
+            .flat_map(|entry| {
+                match entry {
+                    Entry::Message(message) => Some(Self::process_message(message)),
+                    Entry::Comment(_) => {
+                        // Standalone comments are ignored - only use parser's built-in comment association
+                        None
+                    }
+                    Entry::GroupComment(_) | Entry::ResourceComment(_) => {
+                        // Ignore group and resource comments for now
+                        None
+                    }
+                    Entry::Term(_) => {
+                        // Handle terms if needed in the future
+                        None
+                    }
+                    Entry::Junk { .. } => {
+                        // Ignore junk entries
+                        None
+                    }
                 }
-                Entry::GroupComment(_) | Entry::ResourceComment(_) => {
-                    // Ignore group and resource comments for now
-                }
-                Entry::Term(_) => {
-                    // Handle terms if needed in the future
-                }
-                Entry::Junk { .. } => {
-                    // Ignore junk entries
-                }
-            }
-        }
-        Ok(())
+            })
+            .collect()
     }
 
-    fn process_message(&mut self, message: fluent_syntax::ast::Message<&str>) {
+    fn process_message(message: fluent_syntax::ast::Message<&str>) -> FluentMessage {
         let message_id = message.id.name.to_string();
 
         // Only use comments directly associated with the message by the fluent-syntax parser
@@ -56,18 +53,15 @@ impl FluentResourceParser {
             .comment
             .map(|msg_comment| msg_comment.content.join("\n"));
 
-        let fluent_message = FluentMessage {
+        FluentMessage {
             id: message_id,
             value: message.value.map(|pattern| convert_pattern(&pattern)),
-            attributes: self.convert_attributes(message.attributes),
+            attributes: Self::convert_attributes(message.attributes),
             comment,
-        };
-
-        self.messages.push(fluent_message);
+        }
     }
 
     fn convert_attributes(
-        &self,
         attributes: Vec<fluent_syntax::ast::Attribute<&str>>,
     ) -> HashMap<String, FluentPattern> {
         attributes

--- a/src/shared/fluent_resource_parser.rs
+++ b/src/shared/fluent_resource_parser.rs
@@ -26,22 +26,6 @@ impl FluentResourceParser {
             .collect()
     }
 
-    pub fn process_message(message: fluent_syntax::ast::Message<&str>) -> FluentMessage {
-        let message_id = message.id.name.to_string();
-
-        // Only use comments directly associated with the message by the fluent-syntax parser
-        let comment = message
-            .comment
-            .map(|msg_comment| msg_comment.content.join("\n"));
-
-        FluentMessage {
-            id: message_id,
-            value: message.value.map(|pattern| Self::convert_pattern(&pattern)),
-            attributes: Self::convert_attributes(message.attributes),
-            comment,
-        }
-    }
-
     pub fn convert_attributes(
         attributes: Vec<fluent_syntax::ast::Attribute<&str>>,
     ) -> HashMap<String, FluentPattern> {

--- a/src/shared/fluent_resource_parser.rs
+++ b/src/shared/fluent_resource_parser.rs
@@ -1,7 +1,6 @@
 use crate::shared::fluent_data::{FluentElement, FluentMessage, FluentPattern, FluentResource};
 use anyhow::Result;
 use fluent_syntax::ast::{Entry, Expression, InlineExpression, Pattern, PatternElement};
-use fluent_syntax::parser::parse;
 use std::collections::HashMap;
 
 // Constants for better maintainability
@@ -79,7 +78,7 @@ impl FluentResourceParser {
 }
 
 fn parse_with_error_handling(source: &str) -> Result<fluent_syntax::ast::Resource<&str>> {
-    match parse(source) {
+    match fluent_syntax::parser::parse(source) {
         Ok(resource) => Ok(resource),
         Err((_resource, errors)) => Err(anyhow::anyhow!("Fluent parse errors: {:#?}", errors)),
     }

--- a/src/shared/fluent_resource_parser.rs
+++ b/src/shared/fluent_resource_parser.rs
@@ -11,7 +11,7 @@ pub struct FluentResourceParser;
 
 impl FluentResourceParser {
     pub fn parse_source(source: &str) -> Result<FluentResource> {
-        let resource = parse_with_error_handling(source)?;
+        let resource = Self::parse_with_error_handling(source)?;
 
         Ok(FluentResource {
             messages: Self::process_entries(resource.body),
@@ -36,87 +36,89 @@ impl FluentResourceParser {
 
         FluentMessage {
             id: message_id,
-            value: message.value.map(|pattern| convert_pattern(&pattern)),
+            value: message.value.map(|pattern| Self::convert_pattern(&pattern)),
             attributes: Self::convert_attributes(message.attributes),
             comment,
         }
     }
 
-    fn convert_attributes(
+    pub fn convert_attributes(
         attributes: Vec<fluent_syntax::ast::Attribute<&str>>,
     ) -> HashMap<String, FluentPattern> {
         attributes
             .into_iter()
-            .map(|attr| (attr.id.name.to_string(), convert_pattern(&attr.value)))
+            .map(|attr| (attr.id.name.to_string(), Self::convert_pattern(&attr.value)))
             .collect()
     }
-}
 
-fn parse_with_error_handling(source: &str) -> Result<fluent_syntax::ast::Resource<&str>> {
-    match fluent_syntax::parser::parse(source) {
-        Ok(resource) => Ok(resource),
-        Err((_resource, errors)) => Err(anyhow::anyhow!("Fluent parse errors: {:#?}", errors)),
-    }
-}
-
-fn convert_pattern(pattern: &Pattern<&str>) -> FluentPattern {
-    let elements = pattern
-        .elements
-        .iter()
-        .map(convert_pattern_element)
-        .collect();
-
-    FluentPattern { elements }
-}
-
-fn convert_pattern_element(element: &PatternElement<&str>) -> FluentElement {
-    match element {
-        PatternElement::TextElement { value } => FluentElement::Text(value.to_string()),
-        PatternElement::Placeable { expression } => convert_expression(expression),
-    }
-}
-
-fn convert_expression(expression: &Expression<&str>) -> FluentElement {
-    match expression {
-        Expression::Inline(InlineExpression::VariableReference { id }) => {
-            FluentElement::Variable(id.name.to_string())
-        }
-        Expression::Select { selector, variants } => convert_select_expression(selector, variants),
-        _ => FluentElement::Text(UNSUPPORTED_PLACEHOLDER.to_string()),
-    }
-}
-
-fn convert_select_expression(
-    selector: &InlineExpression<&str>,
-    variants: &[fluent_syntax::ast::Variant<&str>],
-) -> FluentElement {
-    if let InlineExpression::VariableReference { id } = selector {
-        let selector_name = id.name.to_string();
-        let variant_map = variants
+    pub fn convert_pattern(pattern: &Pattern<&str>) -> FluentPattern {
+        let elements = pattern
+            .elements
             .iter()
-            .map(|variant| {
-                let key = variant_key_to_string(&variant.key);
-                let pattern = convert_pattern(&variant.value);
-                (key, pattern)
-            })
+            .map(Self::convert_pattern_element)
             .collect();
 
-        FluentElement::Plural {
-            selector: selector_name,
-            variants: variant_map,
-        }
-    } else {
-        FluentElement::Text(UNSUPPORTED_PLACEHOLDER.to_string())
+        FluentPattern { elements }
     }
-}
 
-fn variant_key_to_string(key: &fluent_syntax::ast::VariantKey<&str>) -> String {
-    match key {
-        fluent_syntax::ast::VariantKey::Identifier { name } => name.to_string(),
-        fluent_syntax::ast::VariantKey::NumberLiteral { value } => {
-            // Preserve the actual numeric value - don't convert to named forms
-            // This is important for round-trip conversion especially for PO format
-            value.to_string()
+    fn parse_with_error_handling(source: &str) -> Result<fluent_syntax::ast::Resource<&str>> {
+        match fluent_syntax::parser::parse(source) {
+            Ok(resource) => Ok(resource),
+            Err((_resource, errors)) => Err(anyhow::anyhow!("Fluent parse errors: {:#?}", errors)),
+        }
+    }
+
+    fn convert_pattern_element(element: &PatternElement<&str>) -> FluentElement {
+        match element {
+            PatternElement::TextElement { value } => FluentElement::Text(value.to_string()),
+            PatternElement::Placeable { expression } => Self::convert_expression(expression),
+        }
+    }
+
+    fn convert_expression(expression: &Expression<&str>) -> FluentElement {
+        match expression {
+            Expression::Inline(InlineExpression::VariableReference { id }) => {
+                FluentElement::Variable(id.name.to_string())
+            }
+            Expression::Select { selector, variants } => {
+                Self::convert_select_expression(selector, variants)
+            }
+            _ => FluentElement::Text(UNSUPPORTED_PLACEHOLDER.to_string()),
+        }
+    }
+
+    fn convert_select_expression(
+        selector: &InlineExpression<&str>,
+        variants: &[fluent_syntax::ast::Variant<&str>],
+    ) -> FluentElement {
+        if let InlineExpression::VariableReference { id } = selector {
+            let selector_name = id.name.to_string();
+            let variant_map = variants
+                .iter()
+                .map(|variant| {
+                    let key = Self::variant_key_to_string(&variant.key);
+                    let pattern = Self::convert_pattern(&variant.value);
+                    (key, pattern)
+                })
+                .collect();
+
+            FluentElement::Plural {
+                selector: selector_name,
+                variants: variant_map,
+            }
+        } else {
+            FluentElement::Text(UNSUPPORTED_PLACEHOLDER.to_string())
+        }
+    }
+
+    fn variant_key_to_string(key: &fluent_syntax::ast::VariantKey<&str>) -> String {
+        match key {
+            fluent_syntax::ast::VariantKey::Identifier { name } => name.to_string(),
+            fluent_syntax::ast::VariantKey::NumberLiteral { value } => {
+                // Preserve the actual numeric value - don't convert to named forms
+                // This is important for round-trip conversion especially for PO format
+                value.to_string()
+            }
         }
     }
 }
@@ -297,10 +299,16 @@ goodbye = Goodbye!"#;
     fn test_variant_key_conversion() {
         // Test that numeric values are preserved as-is for round-trip conversion
         let numeric_key = fluent_syntax::ast::VariantKey::NumberLiteral { value: "1" };
-        assert_eq!(variant_key_to_string(&numeric_key), "1");
+        assert_eq!(
+            FluentResourceParser::variant_key_to_string(&numeric_key),
+            "1"
+        );
 
         let identifier_key = fluent_syntax::ast::VariantKey::Identifier { name: "few" };
-        assert_eq!(variant_key_to_string(&identifier_key), "few");
+        assert_eq!(
+            FluentResourceParser::variant_key_to_string(&identifier_key),
+            "few"
+        );
     }
 
     #[test]

--- a/src/shared/fluent_resource_parser.rs
+++ b/src/shared/fluent_resource_parser.rs
@@ -11,7 +11,10 @@ pub struct FluentResourceParser;
 
 impl FluentResourceParser {
     pub fn parse_source(source: &str) -> Result<FluentResource> {
-        let resource = Self::parse_with_error_handling(source)?;
+        let resource = match fluent_syntax::parser::parse(source) {
+            Ok(resource) => Ok(resource),
+            Err((_resource, errors)) => Err(anyhow::anyhow!("Fluent parse errors: {:#?}", errors)),
+        }?;
 
         Ok(FluentResource {
             messages: Self::process_entries(resource.body),
@@ -33,13 +36,6 @@ impl FluentResourceParser {
             .iter()
             .map(|attr| (attr.id.name.to_string(), (&attr.value).into()))
             .collect()
-    }
-
-    fn parse_with_error_handling(source: &str) -> Result<fluent_syntax::ast::Resource<&str>> {
-        match fluent_syntax::parser::parse(source) {
-            Ok(resource) => Ok(resource),
-            Err((_resource, errors)) => Err(anyhow::anyhow!("Fluent parse errors: {:#?}", errors)),
-        }
     }
 
     pub fn convert_select_expression(

--- a/src/shared/fluent_resource_parser.rs
+++ b/src/shared/fluent_resource_parser.rs
@@ -1,6 +1,6 @@
 use crate::shared::fluent_data::{FluentElement, FluentMessage, FluentPattern, FluentResource};
 use anyhow::Result;
-use fluent_syntax::ast::{Entry, InlineExpression, PatternElement};
+use fluent_syntax::ast::{Entry, InlineExpression};
 use std::collections::HashMap;
 
 // Constants for better maintainability
@@ -39,13 +39,6 @@ impl FluentResourceParser {
         match fluent_syntax::parser::parse(source) {
             Ok(resource) => Ok(resource),
             Err((_resource, errors)) => Err(anyhow::anyhow!("Fluent parse errors: {:#?}", errors)),
-        }
-    }
-
-    pub fn convert_pattern_element(element: &PatternElement<&str>) -> FluentElement {
-        match element {
-            PatternElement::TextElement { value } => FluentElement::Text(value.to_string()),
-            PatternElement::Placeable { expression } => expression.into(),
         }
     }
 

--- a/src/shared/fluent_resource_parser.rs
+++ b/src/shared/fluent_resource_parser.rs
@@ -1,7 +1,6 @@
 use crate::shared::fluent_data::{FluentElement, FluentMessage, FluentPattern, FluentResource};
 use anyhow::Result;
 use fluent_syntax::ast::{Entry, InlineExpression};
-use std::collections::HashMap;
 
 // Constants for better maintainability
 pub const UNSUPPORTED_PLACEHOLDER: &str = "{unsupported}";
@@ -26,15 +25,6 @@ impl FluentResourceParser {
             .into_iter()
             .map(TryFrom::try_from)
             .flat_map(Result::ok)
-            .collect()
-    }
-
-    pub fn convert_attributes(
-        attributes: Vec<fluent_syntax::ast::Attribute<&str>>,
-    ) -> HashMap<String, FluentPattern> {
-        attributes
-            .iter()
-            .map(|attr| (attr.id.name.to_string(), (&attr.value).into()))
             .collect()
     }
 

--- a/src/shared/fluent_resource_parser.rs
+++ b/src/shared/fluent_resource_parser.rs
@@ -21,31 +21,12 @@ impl FluentResourceParser {
     fn process_entries(entries: Vec<Entry<&str>>) -> Vec<FluentMessage> {
         entries
             .into_iter()
-            .flat_map(|entry| {
-                match entry {
-                    Entry::Message(message) => Some(Self::process_message(message)),
-                    Entry::Comment(_) => {
-                        // Standalone comments are ignored - only use parser's built-in comment association
-                        None
-                    }
-                    Entry::GroupComment(_) | Entry::ResourceComment(_) => {
-                        // Ignore group and resource comments for now
-                        None
-                    }
-                    Entry::Term(_) => {
-                        // Handle terms if needed in the future
-                        None
-                    }
-                    Entry::Junk { .. } => {
-                        // Ignore junk entries
-                        None
-                    }
-                }
-            })
+            .map(TryFrom::try_from)
+            .flat_map(Result::ok)
             .collect()
     }
 
-    fn process_message(message: fluent_syntax::ast::Message<&str>) -> FluentMessage {
+    pub fn process_message(message: fluent_syntax::ast::Message<&str>) -> FluentMessage {
         let message_id = message.id.name.to_string();
 
         // Only use comments directly associated with the message by the fluent-syntax parser

--- a/src/shared/fluent_resource_parser.rs
+++ b/src/shared/fluent_resource_parser.rs
@@ -1,10 +1,10 @@
 use crate::shared::fluent_data::{FluentElement, FluentMessage, FluentPattern, FluentResource};
 use anyhow::Result;
-use fluent_syntax::ast::{Entry, Expression, InlineExpression, PatternElement};
+use fluent_syntax::ast::{Entry, InlineExpression, PatternElement};
 use std::collections::HashMap;
 
 // Constants for better maintainability
-const UNSUPPORTED_PLACEHOLDER: &str = "{unsupported}";
+pub const UNSUPPORTED_PLACEHOLDER: &str = "{unsupported}";
 
 /// Internal parser state for processing Fluent AST entries
 pub struct FluentResourceParser;
@@ -45,23 +45,11 @@ impl FluentResourceParser {
     pub fn convert_pattern_element(element: &PatternElement<&str>) -> FluentElement {
         match element {
             PatternElement::TextElement { value } => FluentElement::Text(value.to_string()),
-            PatternElement::Placeable { expression } => Self::convert_expression(expression),
+            PatternElement::Placeable { expression } => expression.into(),
         }
     }
 
-    fn convert_expression(expression: &Expression<&str>) -> FluentElement {
-        match expression {
-            Expression::Inline(InlineExpression::VariableReference { id }) => {
-                FluentElement::Variable(id.name.to_string())
-            }
-            Expression::Select { selector, variants } => {
-                Self::convert_select_expression(selector, variants)
-            }
-            _ => FluentElement::Text(UNSUPPORTED_PLACEHOLDER.to_string()),
-        }
-    }
-
-    fn convert_select_expression(
+    pub fn convert_select_expression(
         selector: &InlineExpression<&str>,
         variants: &[fluent_syntax::ast::Variant<&str>],
     ) -> FluentElement {

--- a/src/shared/fluent_resource_parser.rs
+++ b/src/shared/fluent_resource_parser.rs
@@ -1,6 +1,6 @@
 use crate::shared::fluent_data::{FluentElement, FluentMessage, FluentPattern, FluentResource};
 use anyhow::Result;
-use fluent_syntax::ast::{Entry, Expression, InlineExpression, Pattern, PatternElement};
+use fluent_syntax::ast::{Entry, Expression, InlineExpression, PatternElement};
 use std::collections::HashMap;
 
 // Constants for better maintainability
@@ -33,16 +33,6 @@ impl FluentResourceParser {
             .iter()
             .map(|attr| (attr.id.name.to_string(), (&attr.value).into()))
             .collect()
-    }
-
-    pub fn convert_pattern(pattern: &Pattern<&str>) -> FluentPattern {
-        let elements = pattern
-            .elements
-            .iter()
-            .map(Self::convert_pattern_element)
-            .collect();
-
-        FluentPattern { elements }
     }
 
     fn parse_with_error_handling(source: &str) -> Result<fluent_syntax::ast::Resource<&str>> {
@@ -81,7 +71,7 @@ impl FluentResourceParser {
                 .iter()
                 .map(|variant| {
                     let key = Self::variant_key_to_string(&variant.key);
-                    let pattern = Self::convert_pattern(&variant.value);
+                    let pattern = FluentPattern::from(&variant.value);
                     (key, pattern)
                 })
                 .collect();


### PR DESCRIPTION
This PR refactors the `FluentResourceParser` to improve code organization and maintainability. There are no functional changes.

## Changes

- **Simplified parser structure** by removing mutability from `FluentResourceParser`
- **Moved conversion logic** from parser methods to `From` trait implementations
- **Improved error handling** with proper `Result<()>` return from main

## Why These Changes Were Made

The refactoring improves code organization by:
- Following Rust idioms with `From`/`TryFrom` trait implementations instead of custom conversion methods
- Reducing parser complexity by moving conversion logic to the appropriate data structures
- Making the codebase more maintainable and easier to understand

## Files Changed

- `src/main.rs` - Updated to return `Result<()>` from main
- `src/shared/fluent_data.rs` - Added `From` trait implementations for data conversions
- `src/shared/fluent_resource_parser.rs` - Simplified parser by removing conversion methods


## Further Improvement Ideas

- **Consolidate modules** - Consider removing `fluent_resource_parser.rs` entirely and combining it with `fluent_data.rs`. The parser now primarily consists of a single parsing function, while the data structures and their conversions are already in `fluent_data.rs`.
- **Relocate tests** - The tests in `fluent_resource_parser.rs` include extensive testing for `fluent_data` structures, which would be more appropriately located alongside the data definitions.