### PR TITLE
`po_format` Module Mutability Improvements

### DIFF
--- a/src/po/converter.rs
+++ b/src/po/converter.rs
@@ -27,7 +27,7 @@ pub fn fluent_to_po(
     };
 
     // Convert to PO
-    let po_catalog = fluent_to_po_catalog(fluent_resource, locale, source_resource)?;
+    let po_catalog = fluent_to_po_catalog(fluent_resource, locale, source_resource);
 
     // Write PO file with proper CLDR plural forms
     po_file::write(&po_catalog, output_path)

--- a/src/po/po_format.rs
+++ b/src/po/po_format.rs
@@ -256,32 +256,25 @@ fn convert_main_message_value(
     locale: &str,
 ) -> Result<()> {
     let target_text = extract_pattern_text(pattern);
-    let comments = message.comment.as_ref().unwrap_or(&String::new()).clone();
+    let comments = message.comment.as_ref().cloned().unwrap_or_default();
 
-    if let Some(plural_info) = extract_plural_info(pattern) {
-        convert_plural_message(
-            catalog,
-            message,
-            &plural_info,
-            source_message,
-            &comments,
-            locale,
-        )?;
+    let message = if let Some(plural_info) = extract_plural_info(pattern) {
+        convert_plural_message(message, &plural_info, source_message, &comments, locale)?
     } else {
-        convert_singular_message(catalog, message, &target_text, source_message, &comments)?;
-    }
+        convert_singular_message(message, &target_text, source_message, &comments)?
+    };
+    catalog.append_or_update(message);
 
     Ok(())
 }
 
 fn convert_plural_message(
-    catalog: &mut Catalog,
     message: &FluentMessage,
     plural_info: &PluralInfo,
     source_message: Option<&FluentMessage>,
     comments: &str,
     locale: &str,
-) -> Result<()> {
+) -> Result<PoMessage> {
     // Simplified logic: directly get plural forms without multiple wrapper functions
     let (msgid, msgid_plural, msgstr_forms) = if let Some(source_msg) = source_message {
         // Check if source has plural info
@@ -316,18 +309,15 @@ fn convert_plural_message(
     if !combined_comments.is_empty() {
         msg_builder.with_comments(combined_comments);
     }
-
-    catalog.append_or_update(msg_builder.done());
-    Ok(())
+    Ok(msg_builder.done())
 }
 
 fn convert_singular_message(
-    catalog: &mut Catalog,
     message: &FluentMessage,
     target_text: &str,
     source_message: Option<&FluentMessage>,
     comments: &str,
-) -> Result<()> {
+) -> Result<PoMessage> {
     let msgid = get_source_text_or_target(source_message, target_text);
 
     let mut msg_builder = PoMessage::build_singular();
@@ -340,8 +330,7 @@ fn convert_singular_message(
         msg_builder.with_comments(comments.to_string());
     }
 
-    catalog.append_or_update(msg_builder.done());
-    Ok(())
+    Ok(msg_builder.done())
 }
 
 fn convert_message_attributes(

--- a/src/po/po_format.rs
+++ b/src/po/po_format.rs
@@ -45,6 +45,12 @@ const DEFAULT_LANGUAGE: &str = "en";
 const FLUENT_SELECTOR_PREFIX: &str = "FLUENT_SELECTOR:";
 
 // =============================================================================
+// Helper Types
+// =============================================================================
+
+type FluentMessageToPoResult = (Option<PoMessage>, Vec<PoMessage>);
+
+// =============================================================================
 // Public API Functions
 // =============================================================================
 
@@ -82,18 +88,26 @@ pub fn fluent_to_po_catalog(
     target_resource: FluentResource,
     locale: &str,
     source_resource: Option<FluentResource>,
-) -> Result<Catalog> {
+) -> Catalog {
     let metadata = create_po_metadata(locale);
+    let source_lookup = create_source_message_lookup(source_resource.as_ref());
     let mut catalog = Catalog::new(metadata);
 
-    let source_lookup = create_source_message_lookup(source_resource.as_ref());
+    target_resource.messages.iter().for_each(|fluent_message| {
+        let source_message = source_lookup.get(&fluent_message.id).copied();
 
-    for message in target_resource.messages {
-        let source_message = source_lookup.get(&message.id).copied();
-        convert_fluent_message_to_po(&mut catalog, &message, source_message, locale)?;
-    }
+        let (main_message, message_attributes) =
+            convert_fluent_message_to_po(fluent_message, source_message, locale);
 
-    Ok(catalog)
+        if let Some(m) = main_message {
+            catalog.append_or_update(m);
+        };
+        message_attributes.into_iter().for_each(|m| {
+            catalog.append_or_update(m);
+        });
+    });
+
+    catalog
 }
 
 /// Convert a PO catalog to FluentResource
@@ -232,24 +246,16 @@ struct PluralInfo {
 // =============================================================================
 
 fn convert_fluent_message_to_po(
-    catalog: &mut Catalog,
     message: &FluentMessage,
     source_message: Option<&FluentMessage>,
     locale: &str,
-) -> Result<()> {
-    // Convert main message value
-    if let Some(pattern) = &message.value {
-        let message = convert_main_message_value(message, pattern, source_message, locale)?;
-        catalog.append_or_update(message);
-    }
-
-    // Convert attributes
-    let messages = convert_message_attributes(message, source_message);
-    messages.into_iter().for_each(|m| {
-        catalog.append_or_update(m);
-    });
-
-    Ok(())
+) -> FluentMessageToPoResult {
+    let main_message = message
+        .value
+        .as_ref()
+        .map(|pattern| convert_main_message_value(message, pattern, source_message, locale));
+    let message_attributes = convert_message_attributes(message, source_message);
+    (main_message, message_attributes)
 }
 
 fn convert_main_message_value(
@@ -257,7 +263,7 @@ fn convert_main_message_value(
     pattern: &FluentPattern,
     source_message: Option<&FluentMessage>,
     locale: &str,
-) -> Result<PoMessage> {
+) -> PoMessage {
     let target_text = extract_pattern_text(pattern);
     let comments = message.comment.as_ref().cloned().unwrap_or_default();
 
@@ -274,7 +280,7 @@ fn convert_plural_message(
     source_message: Option<&FluentMessage>,
     comments: &str,
     locale: &str,
-) -> Result<PoMessage> {
+) -> PoMessage {
     // Simplified logic: directly get plural forms without multiple wrapper functions
     let (msgid, msgid_plural, msgstr_forms) = if let Some(source_msg) = source_message {
         // Check if source has plural info
@@ -309,7 +315,7 @@ fn convert_plural_message(
     if !combined_comments.is_empty() {
         msg_builder.with_comments(combined_comments);
     }
-    Ok(msg_builder.done())
+    msg_builder.done()
 }
 
 fn convert_singular_message(
@@ -317,7 +323,7 @@ fn convert_singular_message(
     target_text: &str,
     source_message: Option<&FluentMessage>,
     comments: &str,
-) -> Result<PoMessage> {
+) -> PoMessage {
     let msgid = get_source_text_or_target(source_message, target_text);
 
     let mut msg_builder = PoMessage::build_singular();
@@ -330,7 +336,7 @@ fn convert_singular_message(
         msg_builder.with_comments(comments.to_string());
     }
 
-    Ok(msg_builder.done())
+    msg_builder.done()
 }
 
 fn convert_message_attributes(
@@ -725,10 +731,7 @@ mod tests {
             messages: fluent_messages,
         };
 
-        let result = fluent_to_po_catalog(fluent_resource, "en", None);
-        assert!(result.is_ok());
-
-        let catalog = result.unwrap();
+        let catalog = fluent_to_po_catalog(fluent_resource, "en", None);
         assert_eq!(catalog.messages().count(), 3);
 
         // Check metadata

--- a/src/po/po_format.rs
+++ b/src/po/po_format.rs
@@ -569,7 +569,7 @@ fn create_combined_comments(existing_comments: &str, selector: &str) -> String {
 }
 
 fn extract_plural_info(pattern: &FluentPattern) -> Option<PluralInfo> {
-    for element in &pattern.elements {
+    pattern.elements.iter().find_map(|element| {
         if let FluentElement::Plural { selector, variants } = element {
             let forms: Vec<(String, String)> = variants
                 .iter()
@@ -579,15 +579,18 @@ fn extract_plural_info(pattern: &FluentPattern) -> Option<PluralInfo> {
                 })
                 .collect();
 
-            if !forms.is_empty() {
-                return Some(PluralInfo {
+            if forms.is_empty() {
+                None
+            } else {
+                Some(PluralInfo {
                     selector: selector.clone(),
                     forms,
-                });
+                })
             }
+        } else {
+            None
         }
-    }
-    None
+    })
 }
 
 fn create_po_plural_forms(plural_info: &PluralInfo, locale: &str) -> (String, String, Vec<String>) {

--- a/src/po/po_format.rs
+++ b/src/po/po_format.rs
@@ -239,33 +239,33 @@ fn convert_fluent_message_to_po(
 ) -> Result<()> {
     // Convert main message value
     if let Some(pattern) = &message.value {
-        convert_main_message_value(catalog, message, pattern, source_message, locale)?;
+        let message = convert_main_message_value(message, pattern, source_message, locale)?;
+        catalog.append_or_update(message);
     }
 
     // Convert attributes
-    convert_message_attributes(catalog, message, source_message)?;
+    let messages = convert_message_attributes(message, source_message);
+    messages.into_iter().for_each(|m| {
+        catalog.append_or_update(m);
+    });
 
     Ok(())
 }
 
 fn convert_main_message_value(
-    catalog: &mut Catalog,
     message: &FluentMessage,
     pattern: &FluentPattern,
     source_message: Option<&FluentMessage>,
     locale: &str,
-) -> Result<()> {
+) -> Result<PoMessage> {
     let target_text = extract_pattern_text(pattern);
     let comments = message.comment.as_ref().cloned().unwrap_or_default();
 
-    let message = if let Some(plural_info) = extract_plural_info(pattern) {
-        convert_plural_message(message, &plural_info, source_message, &comments, locale)?
+    if let Some(plural_info) = extract_plural_info(pattern) {
+        convert_plural_message(message, &plural_info, source_message, &comments, locale)
     } else {
-        convert_singular_message(message, &target_text, source_message, &comments)?
-    };
-    catalog.append_or_update(message);
-
-    Ok(())
+        convert_singular_message(message, &target_text, source_message, &comments)
+    }
 }
 
 fn convert_plural_message(
@@ -334,30 +334,31 @@ fn convert_singular_message(
 }
 
 fn convert_message_attributes(
-    catalog: &mut Catalog,
     message: &FluentMessage,
     source_message: Option<&FluentMessage>,
-) -> Result<()> {
-    for (attr_name, attr_pattern) in &message.attributes {
-        let attr_msgctxt = format!("{}.{}", message.id, attr_name);
-        let target_attr_text = extract_pattern_text(attr_pattern);
+) -> Vec<PoMessage> {
+    message
+        .attributes
+        .iter()
+        .map(|(attr_name, attr_pattern)| {
+            let attr_msgctxt = format!("{}.{}", message.id, attr_name);
+            let target_attr_text = extract_pattern_text(attr_pattern);
 
-        let source_attr_text = source_message
-            .and_then(|sm| sm.attributes.get(attr_name))
-            .map(extract_pattern_text);
+            let source_attr_text = source_message
+                .and_then(|sm| sm.attributes.get(attr_name))
+                .map(extract_pattern_text);
 
-        let msgid = source_attr_text.unwrap_or_else(|| target_attr_text.clone());
+            let msgid = source_attr_text.unwrap_or_else(|| target_attr_text.clone());
 
-        let mut msg_builder = PoMessage::build_singular();
-        msg_builder
-            .with_msgctxt(attr_msgctxt)
-            .with_msgid(msgid)
-            .with_msgstr(target_attr_text);
+            let mut msg_builder = PoMessage::build_singular();
+            msg_builder
+                .with_msgctxt(attr_msgctxt)
+                .with_msgid(msgid)
+                .with_msgstr(target_attr_text);
 
-        catalog.append_or_update(msg_builder.done());
-    }
-
-    Ok(())
+            msg_builder.done()
+        })
+        .collect()
 }
 
 fn convert_singular_po_message_to_fluent_message(


### PR DESCRIPTION
## Summary
- Removed unnecessary mutability from `convert_fluent_message_to_po` function
- Simplified return types by returning `PoMessage` structs directly instead of unused `Result` wrappers
- Improved code clarity with `find_map` instead of verbose iterator patterns

## Changes
- `convert_fluent_message_to_po`: Removed `mut` keyword for immutable operations
- `convert_main_message_value` & `convert_message_attributes`: Return `PoMessage` instead of `Result<PoMessage>`
- `convert_plural_message` & `convert_singular_message`: Return `PoMessage` instead of `Result<PoMessage>`
- `extract_plural_info`: Use `find_map` for cleaner functional programming style

These changes eliminate unnecessary error handling paths and mutability, making the code more idiomatic and easier to understand.
